### PR TITLE
[DEV-236314] oauth demo bank app supports citibank auth flow

### DIFF
--- a/Sources/TrustlySDK/TrustlyView.swift
+++ b/Sources/TrustlySDK/TrustlyView.swift
@@ -504,7 +504,7 @@ public class TrustlyView : UIView, TrustlyProtocol, WKNavigationDelegate, WKScri
         }
 
         if ("local" == env), let urlLocal = localUrl {
-            url = "http://"+urlLocal+"/start/selectBank/"+fn+"?v="+build+"-ios-sdk"
+            url = "http://"+urlLocal+":8000/start/selectBank/"+fn+"?v="+build+"-ios-sdk"
             isLocalEnvironment = true
             
         } else {

--- a/Sources/TrustlySDK/TrustlyView.swift
+++ b/Sources/TrustlySDK/TrustlyView.swift
@@ -635,7 +635,9 @@ extension TrustlyView {
     }
     
     private func proceedToChooseAccount(){
-        self.mainWebView.evaluateJavaScript("window.Trustly.proceedToChooseAccount();", completionHandler: nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.mainWebView.evaluateJavaScript("window.Trustly.proceedToChooseAccount();", completionHandler: nil)
+        }
     }
     
     // MARK: - Utility Functions

--- a/Sources/TrustlySDK/TrustlyView.swift
+++ b/Sources/TrustlySDK/TrustlyView.swift
@@ -85,7 +85,6 @@ public class TrustlyView : UIView, TrustlyProtocol, WKNavigationDelegate, WKScri
     }
 
     func initView() {
-        self.createNotifications()
         
         if let tempCid = generateCid() {
             cid = tempCid
@@ -180,6 +179,8 @@ public class TrustlyView : UIView, TrustlyProtocol, WKNavigationDelegate, WKScri
 
     public func establish(establishData eD: [AnyHashable : Any], onReturn: TrustlyCallback?, onCancel: TrustlyCallback?) -> UIView? {
         establishData = eD
+        
+        self.createNotifications()
         
         self.addSessionCid()
 
@@ -643,6 +644,9 @@ extension TrustlyView {
     }
     
     @objc func closeWebview(notification: Notification){
+        
+        NotificationCenter.default.removeObserver(self, name: .trustlyCloseWebview, object: nil)
+        
         if webSession != nil {
             webSession.cancel()
         }


### PR DESCRIPTION
### Description

In this pull request we are changing the place where we create and destroy the notification to proceed to choose account, and we added some delay to call the proceed to choose accout function.

---

### Relevant Commits

- [Change where notifications are created and destroyed.](https://github.com/TrustlyInc/trustly-ios/commit/c478d3c82ae2f553fca660e362975c2d411df7b3)
- [Add sleep in the process to proceed to choose account.](https://github.com/TrustlyInc/trustly-ios/commit/9ead2a1ad8d9f4f9bc2c4e8292d6f4834f3b0e79)

---

### Requirements

_(Please check if your pull request fulfills the following requirements)_

- [x] Changes were properly tested
- [x] Repository's code-style/linting compliant

---

### Evidence


https://github.com/user-attachments/assets/8cee84c6-88cd-46cf-8ef8-eb933fa4e64e



---
