### PR TITLE
[DEV-245863] add xctests configuration into ios sdk for code coverage

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - TrustlySDK (3.2.1)
+  - TrustlySDK (3.2.2)
 
 DEPENDENCIES:
   - TrustlySDK (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  TrustlySDK: 8426a3ec86b7ea314fe593401912fab9d7a68db1
+  TrustlySDK: 507ad3f6d631c120bf1cfc1ff366060fb7aced7e
 
 PODFILE CHECKSUM: 2d88e8d6e29e33aaa64b36a8d0e73ac21b25b6ba
 

--- a/Example/TrustlySDK.xcodeproj/project.pbxproj
+++ b/Example/TrustlySDK.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1587AB902A2FE043006F6FC3 /* SessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerTests.swift; sourceTree = "<group>"; };
 		15987B0829DEF79D00D7A395 /* TrustlyLightBoxViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrustlyLightBoxViewController.swift; sourceTree = "<group>"; };
 		15BEC9B32C383FB900050FB9 /* ValidationHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationHelperTests.swift; sourceTree = "<group>"; };
+		15EA22A92CE3D18D00C45E32 /* Unit Tests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Unit Tests.xctestplan"; sourceTree = "<group>"; };
 		2416E32056EECA07B4C86E1B /* TrustlySDK.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = TrustlySDK.podspec; path = ../TrustlySDK.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		24C6055BF6640A73038BF66E /* Pods_TrustlySDK_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TrustlySDK_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		38845E178FF73A019452105E /* Pods-TrustlySDK_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TrustlySDK_Tests.debug.xcconfig"; path = "Target Support Files/Pods-TrustlySDK_Tests/Pods-TrustlySDK_Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -84,6 +85,7 @@
 		607FACC71AFB9204008FA782 = {
 			isa = PBXGroup;
 			children = (
+				15EA22A92CE3D18D00C45E32 /* Unit Tests.xctestplan */,
 				607FACF51AFB993E008FA782 /* Podspec Metadata */,
 				607FACD21AFB9204008FA782 /* Example for TrustlySDK */,
 				607FACE81AFB9204008FA782 /* Tests */,

--- a/Example/TrustlySDK.xcodeproj/project.pbxproj
+++ b/Example/TrustlySDK.xcodeproj/project.pbxproj
@@ -222,7 +222,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 1530;
+				LastUpgradeCheck = 1610;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
@@ -239,10 +239,9 @@
 			};
 			buildConfigurationList = 607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "TrustlySDK" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);

--- a/Example/TrustlySDK.xcodeproj/xcshareddata/xcschemes/TrustlySDK-Example.xcscheme
+++ b/Example/TrustlySDK.xcodeproj/xcshareddata/xcschemes/TrustlySDK-Example.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1530"
-   version = "1.3">
+   LastUpgradeVersion = "1610"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Example/TrustlySDK.xcodeproj/xcshareddata/xcschemes/TrustlySDK-Example.xcscheme
+++ b/Example/TrustlySDK.xcodeproj/xcshareddata/xcschemes/TrustlySDK-Example.xcscheme
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:TrustlySDK.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Unit Tests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Example/TrustlySDK/ViewController.swift
+++ b/Example/TrustlySDK/ViewController.swift
@@ -40,7 +40,7 @@ class ViewController: UIViewController {
             print("onChangeListener: \(eventName) \(attributes)")
         }
 
-        self.trustlyView.selectBankWidget(establishData: establishData) { (view, data) in
+        let _ = self.trustlyView.selectBankWidget(establishData: establishData) { (view, data) in
             print("returnParameters:\(data)")
             self.establishData = data
         }
@@ -85,7 +85,7 @@ extension ViewController: TrustlyLightboxViewProtocol {
     
     // MARK: - Alert functions
     private func showAlert(title: String, message: String){
-        var dialogMessage = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let dialogMessage = UIAlertController(title: title, message: message, preferredStyle: .alert)
         
         // Create OK button with action handler
         let ok = UIAlertAction(title: "OK", style: .default, handler: { (action) -> Void in

--- a/Example/Unit Tests.xctestplan
+++ b/Example/Unit Tests.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "684626F4-CE24-4A19-9D19-ADFCEEF0D713",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:TrustlySDK.xcodeproj",
+        "identifier" : "607FACE41AFB9204008FA782",
+        "name" : "TrustlySDK_Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Sources/TrustlySDK/TrustlyView.swift
+++ b/Sources/TrustlySDK/TrustlyView.swift
@@ -15,7 +15,7 @@
  *   ___________________________________________________________________________________________________________
 */
 import UIKit
-import WebKit
+@preconcurrency import WebKit
 import AuthenticationServices
 import SafariServices
 
@@ -164,7 +164,10 @@ public class TrustlyView : UIView, TrustlyProtocol, WKNavigationDelegate, WKScri
         bankSelectedHandler = onBankSelected
 
         let url = getEndpointUrl(function: "widget", establishData:establishData as! [String : String]) + "&" + urlEncoded(query) + "#" + urlEncoded(hash)
-        var request = URLRequest(url: URL(string: url)!)
+        
+        guard let url = URL(string: url) else { return self }
+        
+        var request = URLRequest(url: url)
 
         request.httpMethod = "GET"
         request.setValue("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", forHTTPHeaderField:"Accept")


### PR DESCRIPTION
### Description

This PR is responsible to enable XCTests and coverage report in trustly iod sdk. 

---

### Relevant Commits

- [Add XCTests Plan](https://github.com/TrustlyInc/trustly-ios/commit/1fa4cf9357067fc98dfbe4b054f941c1acd028af)

---

### Requirements

_(Please check if your pull request fulfills the following requirements)_

- [x] Changes were properly tested (attach evidence if applicable)
- [x] Repository's code-style/linting compliant

---

### Evidence

![image](https://github.com/user-attachments/assets/01181b3a-ee9a-4633-baf4-3cb116589ebc)

---
