### PR TITLE
[DEV-265423] fix persistence of sessioncid and grp in the in app browser version 3.3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ Carthage/Build
 #
 */Podfile.lock
 */Pods/
+
+.build/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ ___
 
 | VERSION   | DESCRIPTION   | BRANCH |
 | :-------: | :-----------  | :----------- |
+3.3.2     | Fix bug to provide some data to analytics | *main*
 3.3.1     | Fix bug when try to send metadata properties | *main*
 3.3.0     | Implement the functionality of being able to choose webview or in-app browser in the SDK | *main*
 3.2.3     | Fix a bug when we try to send an establish data with an array value | *main*

--- a/Sources/TrustlySDK/Utils/Constants.swift
+++ b/Sources/TrustlySDK/Utils/Constants.swift
@@ -9,7 +9,7 @@ import Foundation
 
 
 struct Constants {
-    static let buildSDK = "3.3.1"
+    static let buildSDK = "3.3.2"
     static let baseDomain = "paywithmybank.com"
     
     static let RETURN_URL = "msg://return"

--- a/TrustlySDK.podspec
+++ b/TrustlySDK.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
   s.name             = 'TrustlySDK'
 
-  s.version          = '3.3.1'
+  s.version          = '3.3.2'
 
   s.summary          = 'This SDK help the merchants to integrate their solutions with Trustly Widget and LightBox.'
   s.swift_version    = '5.0'


### PR DESCRIPTION
### Description

This PR change sdk version to 3.3.2
---

### Relevant Commits

[Change version to 3.3.2](https://github.com/TrustlyInc/trustly-ios/commits/4f804bc7a038dc28012474b956e9535adecf823c)

---

### Requirements

- [x] Changes were properly tested (attach evidence if applicable)
- [x] Repository's code-style/linting compliant

---