### PR TITLE
[DEV-294234] Setting metadata.flowtype

### DIFF
--- a/Example/TrustlySDK/InitialViewController.swift
+++ b/Example/TrustlySDK/InitialViewController.swift
@@ -35,7 +35,7 @@ class InitialViewController: UIViewController {
             "metadata.universalLink": "<custom universal link url>",
             "metadata.urlScheme": "demoapp://",
             "description": "First Data Mobile Test",
-            "flowType": "",
+//            "metadata.flowType": "" // Uncomment and set a value in order to use a specific payment flow
             "env": "<[int, sandbox, local]>",
             "localUrl": "<YOUR LOCAL URL WHEN `ENV` PROPERTY IS `LOCAL` (ex: https://192.168.0.30)>"
         ]

--- a/Sources/TrustlySDK/Settings/SettingsManager.swift
+++ b/Sources/TrustlySDK/Settings/SettingsManager.swift
@@ -35,8 +35,8 @@ func getTrustlySettingsWith(establish: [AnyHashable : Any], completionHandler: @
             tokenDictionary["merchantId"] = establish["merchantId"]
             tokenDictionary["grp"] = establish["grp"]
 
-            if establish["flowType"] != nil {
-                tokenDictionary["flowType"] = establish["flowType"]
+            if let flowType = establish["metadata.flowType"] {
+                tokenDictionary["flowType"] = flowType
             }
 
             let normalizedEstablish = EstablishDataUtils.normalizeEstablishWithDotNotation(establish: tokenDictionary as! [String : AnyHashable])


### PR DESCRIPTION
### Description

Fixed the check and assignment of flowtype to metadata.flowtype so that the Lightbox render strategy is loaded properly.

Jira: https://trustly.atlassian.net/browse/DEV-294234

---

### Requirements

_(Please check if your pull request fulfills the following requirements)_

- [x] Changes were properly tested (attach evidence if applicable)
- [x] Repository's code-style/linting compliant

---

### Evidence

WHEN no payment flow is used
THEN  Lightbox Render Strategy defaults to webview
AND integrationContext is InAppBrowser
<img width="722" height="266" alt="Screenshot 2026-02-12 at 15 18 06" src="https://github.com/user-attachments/assets/141e69c8-2010-43e3-bf1c-9e1897941ebd" />
<img width="403" height="263" alt="Screenshot 2026-02-12 at 15 18 55" src="https://github.com/user-attachments/assets/6915e70e-2601-4ff3-9001-52664c43bedd" />

WHEN a payment flow is used
AND  Lightbox Render Strategy is set to webview
THEN integrationContext is InAppBrowser
<img width="691" height="273" alt="Screenshot 2026-02-12 at 15 18 38" src="https://github.com/user-attachments/assets/817fb4e4-151b-4dd8-b594-20fd58196f59" />
<img width="387" height="280" alt="Screenshot 2026-02-12 at 15 19 10" src="https://github.com/user-attachments/assets/d2e13c23-2adc-454c-b49e-08c138171f44" />

WHEN a payment flow is used
AND  Lightbox Render Strategy is set to in-app-browser
THEN integrationContext is SecureBrowser
<img width="695" height="283" alt="Screenshot 2026-02-12 at 15 18 23" src="https://github.com/user-attachments/assets/b63ccd9b-e616-4557-8401-1d40dda0927f" />
<img width="387" height="280" alt="Screenshot 2026-02-12 at 15 19 01" src="https://github.com/user-attachments/assets/6998f28f-5da1-45d2-afcf-627eebda2c6c" />


---
