### PR TITLE
[DEV-275754] save the last used bank after authorize in inappbrowser

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - TrustlySDK (4.1.0)
+  - TrustlySDK (4.2.0)
 
 DEPENDENCIES:
   - TrustlySDK (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  TrustlySDK: 58ea8eadf34364b3fad857a3a602f8e0df32750e
+  TrustlySDK: c6c6da1e891cac722ecd4ddf2dd13c16148b4363
 
 PODFILE CHECKSUM: 2d88e8d6e29e33aaa64b36a8d0e73ac21b25b6ba
 

--- a/Example/Tests/Commons/TrustlyCommonFunctionsTests.swift
+++ b/Example/Tests/Commons/TrustlyCommonFunctionsTests.swift
@@ -1,0 +1,83 @@
+//
+//  TrustlyCommonFunctionsTests.swift
+//  TrustlySDK
+//
+//  Created by Marcos Rivereto on 19/02/26.
+//  Copyright © 2026 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import TrustlySDK
+
+final class TrustlyCommonFunctionsTests: XCTestCase {
+
+    // MARK: - Setup & Teardown
+    override func setUp() {
+        super.setUp()
+
+        UserDefaults.standard.removeObject(forKey: Constants.repositoryTrustlyContext)
+        UserDefaults.standard.removeObject(forKey: Constants.repositoryGRP)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: Constants.repositoryTrustlyContext)
+        UserDefaults.standard.removeObject(forKey: Constants.repositoryGRP)
+        super.tearDown()
+    }
+
+    // MARK: - Tests for getTrustlyContext
+    func testGetTrustlyContext_WhenEmpty_ShouldReturnEmptyString() {
+        let context = getTrustlyContext()
+        
+        XCTAssertEqual(context, "")
+    }
+
+    func testGetTrustlyContext_WhenHasValue_ShouldReturnCorrectValue() {
+
+        let expectedValue = "mock_context"
+        LocalStorage.save(expectedValue, forKey: Constants.repositoryTrustlyContext)
+        
+
+        let context = getTrustlyContext()
+        
+
+        XCTAssertEqual(context, expectedValue)
+    }
+
+    // MARK: - Tests for getGrp
+    func testGetGrp_WhenEmpty_ShouldGenerateAndReturnNewValue() {
+
+        let grp = getGrp()
+        
+        XCTAssertNotNil(grp)
+        XCTAssertFalse(grp.isEmpty)
+        
+        let isNumber = Int(grp) != nil
+        XCTAssertTrue(isNumber, "GRP should be a number")
+    }
+
+    func testGetGrp_WhenHasValue_ShouldNotGenerateNewOne() {
+        // Given
+        let existingGrp = "42"
+        LocalStorage.save(existingGrp, forKey: Constants.repositoryGRP)
+        
+        // When
+        let grp = getGrp()
+        
+        // Then
+        XCTAssertEqual(grp, existingGrp)
+    }
+
+    // MARK: - Tests for generateGrp
+    func testGenerateGrp_ShouldReturnNumberWithinRange() {
+        // When
+        let grp = generateGrp()
+        let grpInt = Int(grp)
+        
+        // Then
+        XCTAssertNotNil(grpInt)
+        if let value = grpInt {
+            XCTAssertTrue(value >= 0 && value < 100, "GRP should be between 0 to 99")
+        }
+    }
+}

--- a/Example/Tests/Repository/LocalStorageTests.swift
+++ b/Example/Tests/Repository/LocalStorageTests.swift
@@ -1,0 +1,49 @@
+//
+//  LocalStorageTests.swift
+//  TrustlySDK
+//
+//  Created by Marcos Rivereto on 19/02/26.
+//  Copyright © 2026 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import TrustlySDK
+
+final class LocalStorageTests: XCTestCase {
+
+    let testKey = "test_key_item"
+    let testValue = "test_value"
+
+    override func setUp() {
+        super.setUp()
+        LocalStorage.userDefaults.removeObject(forKey: testKey)
+    }
+
+    override func tearDown() {
+        LocalStorage.userDefaults.removeObject(forKey: testKey)
+        super.tearDown()
+    }
+
+    func testSaveAndGet_ShouldReturnCorrectValue() {
+        let valueToSave = testValue
+        
+        LocalStorage.save(valueToSave, forKey: testKey)
+        let retrievedValue = LocalStorage.getFrom(key: testKey)
+        
+        XCTAssertEqual(retrievedValue, valueToSave)
+    }
+
+    func testGetFrom_WithEmptyKey_ShouldReturnDefaultValue() {
+        let defaultValue = "fallback"
+
+        let retrievedValue = LocalStorage.getFrom(key: "non_existent_key", defaultValue: defaultValue)
+        
+        XCTAssertEqual(retrievedValue, defaultValue, "Deve retornar o valor padrão quando a chave não existe.")
+    }
+    
+    func testGetFrom_WithoutProvidingDefaultValue_ShouldReturnEmptyString() {
+        let retrievedValue = LocalStorage.getFrom(key: "non_existent_key")
+        
+        XCTAssertEqual(retrievedValue, "", "O valor padrão default da assinatura deve ser uma String vazia.")
+    }
+}

--- a/Example/Tests/Repository/LocalStorageTests.swift
+++ b/Example/Tests/Repository/LocalStorageTests.swift
@@ -38,12 +38,12 @@ final class LocalStorageTests: XCTestCase {
 
         let retrievedValue = LocalStorage.getFrom(key: "non_existent_key", defaultValue: defaultValue)
         
-        XCTAssertEqual(retrievedValue, defaultValue, "Deve retornar o valor padrão quando a chave não existe.")
+        XCTAssertEqual(retrievedValue, defaultValue, "It should return the default value when the key does not exist.")
     }
     
     func testGetFrom_WithoutProvidingDefaultValue_ShouldReturnEmptyString() {
         let retrievedValue = LocalStorage.getFrom(key: "non_existent_key")
         
-        XCTAssertEqual(retrievedValue, "", "O valor padrão default da assinatura deve ser uma String vazia.")
+        XCTAssertEqual(retrievedValue, "", "The default value for the signature should be an empty String.")
     }
 }

--- a/Example/TrustlySDK.xcodeproj/project.pbxproj
+++ b/Example/TrustlySDK.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		15BEC9B42C383FB900050FB9 /* ValidationHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15BEC9B32C383FB900050FB9 /* ValidationHelperTests.swift */; };
 		15C29FB62C6165480037C239 /* SuccessViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 15C29FB52C6165480037C239 /* SuccessViewController.xib */; };
 		15C29FB82C6165570037C239 /* SuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C29FB72C6165570037C239 /* SuccessViewController.swift */; };
+		15D1A45F2F47B664007E5B28 /* LocalStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D1A45E2F47B664007E5B28 /* LocalStorageTests.swift */; };
+		15D1A4622F47B7C1007E5B28 /* TrustlyCommonFunctionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D1A4612F47B7C1007E5B28 /* TrustlyCommonFunctionsTests.swift */; };
 		15D96FB32C46E6B700296BC4 /* NetworkHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D96FB22C46E6B700296BC4 /* NetworkHelperTests.swift */; };
 		15E049852B7510BA0084B71A /* JsonUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15E049842B7510BA0084B71A /* JsonUtilsTests.swift */; };
 		15F713972D9C6EE400F259BE /* DeviceHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F713962D9C6EE400F259BE /* DeviceHelperTests.swift */; };
@@ -57,6 +59,8 @@
 		15BEC9B32C383FB900050FB9 /* ValidationHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationHelperTests.swift; sourceTree = "<group>"; };
 		15C29FB52C6165480037C239 /* SuccessViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SuccessViewController.xib; sourceTree = "<group>"; };
 		15C29FB72C6165570037C239 /* SuccessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuccessViewController.swift; sourceTree = "<group>"; };
+		15D1A45E2F47B664007E5B28 /* LocalStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalStorageTests.swift; sourceTree = "<group>"; };
+		15D1A4612F47B7C1007E5B28 /* TrustlyCommonFunctionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrustlyCommonFunctionsTests.swift; sourceTree = "<group>"; };
 		15D96FB22C46E6B700296BC4 /* NetworkHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkHelperTests.swift; sourceTree = "<group>"; };
 		15E049842B7510BA0084B71A /* JsonUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonUtilsTests.swift; sourceTree = "<group>"; };
 		15EA22A92CE3D18D00C45E32 /* Unit Tests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Unit Tests.xctestplan"; sourceTree = "<group>"; };
@@ -141,6 +145,22 @@
 			name = Session;
 			sourceTree = "<group>";
 		};
+		15D1A4642F47B8E5007E5B28 /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				15D1A45E2F47B664007E5B28 /* LocalStorageTests.swift */,
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
+		15D1A4652F47B924007E5B28 /* Commons */ = {
+			isa = PBXGroup;
+			children = (
+				15D1A4612F47B7C1007E5B28 /* TrustlyCommonFunctionsTests.swift */,
+			);
+			path = Commons;
+			sourceTree = "<group>";
+		};
 		2FFBEBF127FEF263CF329C6F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -198,10 +218,12 @@
 		607FACE81AFB9204008FA782 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				15D1A4652F47B924007E5B28 /* Commons */,
 				15BEC9B22C383F3600050FB9 /* Helpers */,
-				15C29FBC2C6533520037C239 /* Utils */,
+				15D1A4642F47B8E5007E5B28 /* Repository */,
 				15C29FBD2C65336B0037C239 /* Session */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
+				15C29FBC2C6533520037C239 /* Utils */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -421,6 +443,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				15D1A45F2F47B664007E5B28 /* LocalStorageTests.swift in Sources */,
+				15D1A4622F47B7C1007E5B28 /* TrustlyCommonFunctionsTests.swift in Sources */,
 				15BEC9B42C383FB900050FB9 /* ValidationHelperTests.swift in Sources */,
 				15E049852B7510BA0084B71A /* JsonUtilsTests.swift in Sources */,
 				15268E062DF8A5B900EC94E0 /* MerchantWidgetViewController.swift in Sources */,

--- a/Example/TrustlySDK/InitialViewController.swift
+++ b/Example/TrustlySDK/InitialViewController.swift
@@ -31,13 +31,13 @@ class InitialViewController: UIViewController {
             "customer.address.country": "US",
             "theme": "dark",
             "metadata.theme": "dark",
-            "metadata.deepLinkStrategy": "<[url-scheme, universal-link]>",
-            "metadata.universalLink": "<custom universal link url>",
+            "metadata.deepLinkStrategy": "<[url-scheme, deeplink-url]>",
+            "metadata.deepLinkUrl": "<custom deeplink url>",
             "metadata.urlScheme": "demoapp://",
             "description": "First Data Mobile Test",
             "flowType": "",
             "env": "<[int, sandbox, local]>",
-            "localUrl": "<YOUR LOCAL URL WHEN `ENV` PROPERTY IS `LOCAL` (ex: https://192.168.0.30)>"
+            "envHost": "<YOUR LOCAL URL WHEN `ENV` PROPERTY IS `LOCAL` (ex: https://192.168.0.30)>"
         ]
 
     }

--- a/Sources/TrustlySDK/Commons/TrustlyCommonsFunctions.swift
+++ b/Sources/TrustlySDK/Commons/TrustlyCommonsFunctions.swift
@@ -20,3 +20,18 @@ func generateGrp() -> String {
     grp = String(format:"%d", grpInt)
     return grp
 }
+
+func getLastBankUsedFrom(country: String) -> String {
+    
+    let trustlyContextBase64 = getTrustlyContext()
+    
+    if !trustlyContextBase64.isEmpty {
+        let trustlyContext = trustlyContextBase64.base64ToDictionary()
+        
+        if let lastUsed = trustlyContext["lastUsed"] as? [String: String] {
+            return lastUsed[country] ?? ""
+        }
+    }
+    
+    return ""
+}

--- a/Sources/TrustlySDK/Commons/TrustlyCommonsFunctions.swift
+++ b/Sources/TrustlySDK/Commons/TrustlyCommonsFunctions.swift
@@ -1,0 +1,22 @@
+//
+//  TrustlyCommonsFunctions.swift
+//  Pods
+//
+//  Created by Marcos Rivereto on 19/02/26.
+//
+
+
+func getTrustlyContext() -> String {
+    return LocalStorage.getFrom(key: Constants.repositoryTrustlyContext, defaultValue: "")
+}
+
+func getGrp() -> String {
+    return LocalStorage.getFrom(key: Constants.repositoryGRP, defaultValue: generateGrp())
+}
+
+func generateGrp() -> String {
+    var grp:String!
+    let grpInt:Int = Int(arc4random_uniform(100))
+    grp = String(format:"%d", grpInt)
+    return grp
+}

--- a/Sources/TrustlySDK/Controller/LightBoxViewController.swift
+++ b/Sources/TrustlySDK/Controller/LightBoxViewController.swift
@@ -183,6 +183,11 @@ extension LightBoxViewController {
     }
     
     private func onReturn(_ returnParameters: [AnyHashable : Any]) -> Void{
+        
+        if let trustlyContext = returnParameters["trustlyContext"] as? String  {
+            LocalStorage.save(trustlyContext, forKey: Constants.repositoryTrustlyContext)
+        }
+        
         self.delegate?.onReturn(returnParameters)
     }
     

--- a/Sources/TrustlySDK/Extensions/String+Extension.swift
+++ b/Sources/TrustlySDK/Extensions/String+Extension.swift
@@ -19,11 +19,11 @@ extension String {
         return base64String
     }
     
-    func base64ToDictionary() -> [String: Any]? {
+    func base64ToDictionary() -> [String: Any] {
 
         guard let data = Data(base64Encoded: self) else {
             Logs.debug(log: Logs.stringExtensions, message: "Error: Could not decode Base64 string to Data")
-            return nil
+            return [:]
         }
 
         do {
@@ -33,11 +33,11 @@ extension String {
                 return dictionary
             } else {
                 Logs.debug(log: Logs.stringExtensions, message: "Error: JSON object is not a dictionary")
-                return nil
+                return [:]
             }
         } catch {
             Logs.debug(log: Logs.stringExtensions, message: "Error: Could not deserialize Data to JSON object: \(error.localizedDescription)")
-            return nil
+            return [:]
         }
     }
 }

--- a/Sources/TrustlySDK/Extensions/String+Extension.swift
+++ b/Sources/TrustlySDK/Extensions/String+Extension.swift
@@ -18,4 +18,26 @@ extension String {
 
         return base64String
     }
+    
+    func base64ToDictionary() -> [String: Any]? {
+
+        guard let data = Data(base64Encoded: self) else {
+            Logs.debug(log: Logs.stringExtensions, message: "Error: Could not decode Base64 string to Data")
+            return nil
+        }
+
+        do {
+            let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])
+            
+            if let dictionary = jsonObject as? [String: Any] {
+                return dictionary
+            } else {
+                Logs.debug(log: Logs.stringExtensions, message: "Error: JSON object is not a dictionary")
+                return nil
+            }
+        } catch {
+            Logs.debug(log: Logs.stringExtensions, message: "Error: Could not deserialize Data to JSON object: \(error.localizedDescription)")
+            return nil
+        }
+    }
 }

--- a/Sources/TrustlySDK/Helpers/NetworkHelper.swift
+++ b/Sources/TrustlySDK/Helpers/NetworkHelper.swift
@@ -53,7 +53,14 @@ func buildEnvironment(resourceUrl:ResourceUrls, environment: String, localUrl: S
     )
     
     if path == .selectBank {
+        
         urlString = "\(urlString)?v=\(build)-ios-sdk"
+        
+        let lastUsed = getLastBankUsedFrom(country: query?["customer.address.country"] as? String ?? "")
+        if !lastUsed.isEmpty {
+            urlString = "\(urlString)&lastUsed=\(lastUsed)"
+        }
+        
     }
     
     if let query = query {

--- a/Sources/TrustlySDK/Repository/LocalStorage.swift
+++ b/Sources/TrustlySDK/Repository/LocalStorage.swift
@@ -1,0 +1,19 @@
+//
+//  LocalStorage.swift
+//  Pods
+//
+//  Created by Marcos Rivereto on 19/02/26.
+//
+
+class LocalStorage {
+    
+    static let userDefaults:UserDefaults = UserDefaults.standard
+    
+    static func getFrom(key:String, defaultValue: String = "") -> String {
+        return userDefaults.string(forKey: key) ?? defaultValue
+    }
+    
+    static func save(_ value: String, forKey key: String) {
+        userDefaults.set(value,forKey: key)
+    }
+}

--- a/Sources/TrustlySDK/Utils/Constants.swift
+++ b/Sources/TrustlySDK/Utils/Constants.swift
@@ -59,6 +59,9 @@ struct Constants {
     static let categoryJsonUtils = "jsonUtils"
     static let categoryEstablishDataUtils = "establishDataUtils"
     
+    // MARK: Repository Keys
+    static let repositoryGRP = "Trustly.grp"
+    static let repositoryTrustlyContext = "Trustly.trustlyContext"
     
     // MARK: Establish validation
     static let requiredKeys: Set<AnyHashable> = [AnyHashable("accessId"),

--- a/Sources/TrustlySDK/Utils/Constants.swift
+++ b/Sources/TrustlySDK/Utils/Constants.swift
@@ -58,6 +58,7 @@ struct Constants {
     static let categorySettingsManager = "settingsManager"
     static let categoryJsonUtils = "jsonUtils"
     static let categoryEstablishDataUtils = "establishDataUtils"
+    static let categoryStringExtensions = "string+extensions"
     
     // MARK: Repository Keys
     static let repositoryGRP = "Trustly.grp"

--- a/Sources/TrustlySDK/Utils/EstablishDataUtils.swift
+++ b/Sources/TrustlySDK/Utils/EstablishDataUtils.swift
@@ -169,7 +169,12 @@ struct EstablishDataUtils {
                 establishData["returnUrl"] = urlScheme
                 establishData["cancelUrl"] = urlScheme
                 establishData["metadata.integrationContext"] = Constants.secureBrowserIntegrationContext
-                establishData["metadata.trustlyContext"] = getTrustlyContext()
+                
+                let trustlyContext = getTrustlyContext()
+                if !trustlyContext.isEmpty {
+                    establishData["metadata.trustlyContext"] = trustlyContext
+                }
+                
             } else {
                 if establishData.index(forKey: "metadata.integrationContext") == nil {
                     establishData["metadata.integrationContext"] = Constants.inAppIntegrationContext
@@ -193,12 +198,5 @@ struct EstablishDataUtils {
         
         return urlScheme.components(separatedBy: ":")[0]
     }
-    
-//    static func getLastBankUsedFrom(county: String) -> String {
-//        
-//        let trustlyContext:String = getTrustlyContext()
-//        
-//        return ""
-//    }
 
 }

--- a/Sources/TrustlySDK/Utils/EstablishDataUtils.swift
+++ b/Sources/TrustlySDK/Utils/EstablishDataUtils.swift
@@ -151,6 +151,8 @@ struct EstablishDataUtils {
         establishData["grp"] = self.getGrp()
         establishData["dynamicWidget"] = "true"
         establishData["storage"] = Constants.storageSupported
+        establishData["trustlyContext"] = self.getTrustlyContext()
+        establishData["metadata.trustlyContext"] = self.getTrustlyContext()
 
         if establishData["paymentProviderId"] != nil {
             establishData["widgetLoaded"] = "true"
@@ -195,6 +197,10 @@ struct EstablishDataUtils {
     
     static func getGrp() -> String! {
         return getDefault(key: "Trustly.grp", def: generateGrp())
+    }
+    
+    static func getTrustlyContext() -> String! {
+        return getDefault(key: "Trustly.trustlyContext", def: "")
     }
     
     static func getDefault(key:String, def: String) -> String{

--- a/Sources/TrustlySDK/Utils/EstablishDataUtils.swift
+++ b/Sources/TrustlySDK/Utils/EstablishDataUtils.swift
@@ -169,6 +169,7 @@ struct EstablishDataUtils {
                 establishData["returnUrl"] = urlScheme
                 establishData["cancelUrl"] = urlScheme
                 establishData["metadata.integrationContext"] = Constants.secureBrowserIntegrationContext
+                establishData["metadata.trustlyContext"] = getTrustlyContext()
             } else {
                 if establishData.index(forKey: "metadata.integrationContext") == nil {
                     establishData["metadata.integrationContext"] = Constants.inAppIntegrationContext
@@ -193,5 +194,11 @@ struct EstablishDataUtils {
         return urlScheme.components(separatedBy: ":")[0]
     }
     
+//    static func getLastBankUsedFrom(county: String) -> String {
+//        
+//        let trustlyContext:String = getTrustlyContext()
+//        
+//        return ""
+//    }
 
 }

--- a/Sources/TrustlySDK/Utils/EstablishDataUtils.swift
+++ b/Sources/TrustlySDK/Utils/EstablishDataUtils.swift
@@ -148,11 +148,9 @@ struct EstablishDataUtils {
         establishData["version"] = Constants.establishVersion
         establishData["sessionCid"] = sessionCid
         establishData["metadata.cid"] = cid
-        establishData["grp"] = self.getGrp()
+        establishData["grp"] = getGrp()
         establishData["dynamicWidget"] = "true"
         establishData["storage"] = Constants.storageSupported
-        establishData["trustlyContext"] = self.getTrustlyContext()
-        establishData["metadata.trustlyContext"] = self.getTrustlyContext()
 
         if establishData["paymentProviderId"] != nil {
             establishData["widgetLoaded"] = "true"
@@ -195,29 +193,5 @@ struct EstablishDataUtils {
         return urlScheme.components(separatedBy: ":")[0]
     }
     
-    static func getGrp() -> String! {
-        return getDefault(key: "Trustly.grp", def: generateGrp())
-    }
-    
-    static func getTrustlyContext() -> String! {
-        return getDefault(key: "Trustly.trustlyContext", def: "")
-    }
-    
-    static func getDefault(key:String, def: String) -> String{
-        let userDefaults:UserDefaults = UserDefaults.standard
-        var value = userDefaults.object(forKey: key) as? String
-        if(value == nil){
-            value = def
-            userDefaults.set(value,forKey: key)
-            userDefaults.synchronize()
-        }
-        return value ?? ""
-    }
 
-    static func generateGrp() -> String! {
-        var grp:String!
-        let grpInt:Int = Int(arc4random_uniform(100))
-        grp = String(format:"%d", grpInt)
-        return grp
-    }
 }

--- a/Sources/TrustlySDK/Utils/LogUtils.swift
+++ b/Sources/TrustlySDK/Utils/LogUtils.swift
@@ -43,6 +43,9 @@ struct Logs {
     /// All logs related to EstablishDataUtils
     static let establishDataUtils = OSLog(subsystem: subsystem, category: Constants.categoryEstablishDataUtils)
     
+    /// All logs related to String+Extensions
+    static let stringExtensions = OSLog(subsystem: subsystem, category: Constants.categoryStringExtensions)
+
     //Debug-level logs are intended for use in a development environment while actively debugging. This level will not show in device's logs.
     static func debug(log: OSLog, message: String) {
         printLog(log: log, type:.debug, message: message)

--- a/Sources/TrustlySDK/Webview/WebViewManager.swift
+++ b/Sources/TrustlySDK/Webview/WebViewManager.swift
@@ -212,13 +212,12 @@ extension WebViewManager: WKNavigationDelegate {
                     if ("PayWithMyBank.createTransaction" == params[0]) && bankSelectedHandler != nil {
                         if params.count > 1 {
                             establishData?["paymentProviderId"] = params[1]
-                            }
-                            
-                            if let establishData = establishData {
-                                bankSelectedHandler?(establishData)
-                            }
-                            
                         }
+                            
+                        if let establishData = establishData {
+                            bankSelectedHandler?(establishData)
+                        }
+                    }
                         break;
                     case .none:
                         break;


### PR DESCRIPTION
### Description

This PR is responsible for get trustlyContext, save in the local storage, and extract lastUsed information from trustlyContext and send in the query parameter in the widget url.

Jira task: [DEV-275754](https://trustly.atlassian.net/browse/DEV-275754)
---

### Relevant Commits

#### Main commits
[Save trustlyContext from url](https://github.com/TrustlyInc/trustly-ios/commit/a9993a6d6aee82cc69e80e7d2d971c5c5cd6feb4)
[Add lastUsed parameter in the query string in the webview](https://github.com/TrustlyInc/trustly-ios/commit/b3f4a0a86852cac1d690e7edae3503869580959e)
[Create function getLastBankUsedFrom to get lastUsed](https://github.com/TrustlyInc/trustly-ios/commit/609ee4e3956ebc2254152e875848414f9b610e35)
[Add metadata.trustlyContext in the establish](https://github.com/TrustlyInc/trustly-ios/commit/e0f848dea27120316b6704e8870dcee345627af3)
[Create an extension to decode base64 into dictionary](https://github.com/TrustlyInc/trustly-ios/commit/4987e7138e3e86419df2f67e1b27f5b486e7b0fd)

#### Refactor
[Refactor to turn the SDK more testable](https://github.com/TrustlyInc/trustly-ios/commit/6db1297b6aedab85b7e5b93268eb0c86ac0545e8)
[Fix establishData placeholder](https://github.com/TrustlyInc/trustly-ios/commit/10cc3e8442a665b20afa7ae5abaf7e793a0c3d32)

---

### Requirements

- [X] Changes were properly tested (attach evidence if applicable)
- [X] Repository's code-style/linting compliant

---


[DEV-275754]: https://trustly.atlassian.net/browse/DEV-275754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ