### PR TITLE
[DEV-303585]Remove trustlyContext parameter from return and cancel callback methods

### DIFF
--- a/ExampleApp/ExampleAppUIKit/ExampleAppUIKit.xcodeproj/project.pbxproj
+++ b/ExampleApp/ExampleAppUIKit/ExampleAppUIKit.xcodeproj/project.pbxproj
@@ -57,11 +57,15 @@
 		};
 		69525CA02F83FBC3000A5F54 /* ExampleAppUIKitTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = ExampleAppUIKitTests;
 			sourceTree = "<group>";
 		};
 		69525CAA2F83FBC3000A5F54 /* ExampleAppUIKitUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = ExampleAppUIKitUITests;
 			sourceTree = "<group>";
 		};
@@ -298,13 +302,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ExampleAppUIKit/Pods-ExampleAppUIKit-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ExampleAppUIKit/Pods-ExampleAppUIKit-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ExampleApp/ExampleAppUIKit/ExampleAppUIKit.xcodeproj/project.pbxproj
+++ b/ExampleApp/ExampleAppUIKit/ExampleAppUIKit.xcodeproj/project.pbxproj
@@ -57,15 +57,11 @@
 		};
 		69525CA02F83FBC3000A5F54 /* ExampleAppUIKitTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = ExampleAppUIKitTests;
 			sourceTree = "<group>";
 		};
 		69525CAA2F83FBC3000A5F54 /* ExampleAppUIKitUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = ExampleAppUIKitUITests;
 			sourceTree = "<group>";
 		};
@@ -302,9 +298,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ExampleAppUIKit/Pods-ExampleAppUIKit-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ExampleAppUIKit/Pods-ExampleAppUIKit-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ExampleApp/ExampleAppUIKit/Podfile.lock
+++ b/ExampleApp/ExampleAppUIKit/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - TrustlySDK (4.2.0)
+  - TrustlySDK (4.3.0)
 
 DEPENDENCIES:
   - TrustlySDK (from `../..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  TrustlySDK: 9ecce3fdec749558eb08b5b50deaca2e6dbe7ff5
+  TrustlySDK: 6b0bfc19c86fdb9e7d94ab7ee05f1add14ea3ecb
 
 PODFILE CHECKSUM: 9b03f9ac6aff4cba6ed3b16b934bd29ebec4ba4e
 

--- a/ExampleApp/ExampleAppUIKit/Pods/Local Podspecs/TrustlySDK.podspec.json
+++ b/ExampleApp/ExampleAppUIKit/Pods/Local Podspecs/TrustlySDK.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "TrustlySDK",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "summary": "This SDK help the merchants to integrate their solutions with Trustly Widget and LightBox.",
   "swift_versions": "5.0",
   "description": "This cocoapods provides the ability to integrate your application with Trustly Widget and LightBox.",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/TrustlyInc/trustly-ios.git",
-    "tag": "4.2.0"
+    "tag": "4.3.0"
   },
   "platforms": {
     "ios": "12.0"

--- a/ExampleApp/ExampleAppUIKit/Pods/Manifest.lock
+++ b/ExampleApp/ExampleAppUIKit/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - TrustlySDK (4.2.0)
+  - TrustlySDK (4.3.0)
 
 DEPENDENCIES:
   - TrustlySDK (from `../..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  TrustlySDK: 9ecce3fdec749558eb08b5b50deaca2e6dbe7ff5
+  TrustlySDK: 6b0bfc19c86fdb9e7d94ab7ee05f1add14ea3ecb
 
 PODFILE CHECKSUM: 9b03f9ac6aff4cba6ed3b16b934bd29ebec4ba4e
 

--- a/ExampleApp/ExampleAppUIKit/Pods/Pods.xcodeproj/project.pbxproj
+++ b/ExampleApp/ExampleAppUIKit/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,42 +7,43 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0DD83A7639F3D4E3D874BBCD3F854B1E /* AnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225A74AD1FB5CE5DBD05F3655A4B076A /* AnalyticsHelper.swift */; };
-		1797D16862A2DBB4082D491EC73E92F4 /* TrustlySDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E2CF5874763E8909E33B24952815A0 /* TrustlySDK.swift */; };
-		1C060B67D5186C0FF7CED428BF2E4AE6 /* TrustlySDK-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C5F463FA0D7C51B067DACAD856B70792 /* TrustlySDK-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1DE379A837BABE47F2E1BBC5E13605DA /* NetworkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3CC29624818F3541C5B693E029754D /* NetworkHelper.swift */; };
-		246039C1651D6BB3BD151899ADB7B62C /* EstablishDataUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD34BD7EAB7C0F5D1391C73D8D53585 /* EstablishDataUtils.swift */; };
-		257A30DA1045CD0C398DC820C13587C3 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C148CD5265E0F76419F12A0EF85C0E2 /* Constants.swift */; };
+		0044B2EA3E355ACC33AED6BE14CBBDFA /* ValidationsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3994B4F29B69A7FEE96E1A30C61221 /* ValidationsHelper.swift */; };
+		13A4741F461AA8592EF9BDFFB38A0C94 /* JSONUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7EEE1FAAD1B97BC5BC4CD10E62B64F7 /* JSONUtils.swift */; };
+		1CDF2C71D457F389825311F2F75FD98D /* StorageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F19136391CACBEA5F8B2C040DE6A8E /* StorageHelper.swift */; };
+		1CFD157C06A26F21022C3351018FA7A5 /* TrustlyCommonsFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDFD55D45233E2144B4D243B7B5C75A /* TrustlyCommonsFunctions.swift */; };
+		236485AAD27495A4A8BD45CC47DD66AC /* TrustlySDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA9C98396D91AF707AFE8AAE91696BD /* TrustlySDK.swift */; };
+		2369B032E477C98B41AA53BB82421FF4 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F954BC40C074CF002FD863B828715858 /* Constants.swift */; };
 		28689A681B80AB627747CC5C7437BB07 /* Pods-ExampleAppUIKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A25FF4A27FCAB8131058756D28D31847 /* Pods-ExampleAppUIKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2CED90DC88249AB8CE0610872D2E867E /* WebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6155BAC4C983E0E5344DFA04C4DFB2A7 /* WebViewManager.swift */; };
+		47135613CF8B787092A308DC5F38604F /* URLUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC4320181D7775B736B77B2448782F /* URLUtils.swift */; };
+		503F604855E8A3034EEDBAA1723FC716 /* WebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86EABDB9B14918E48D65751FFA93ADE /* WebViewManager.swift */; };
+		515C37EF24FDD2E153196AFA96940A1B /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FCC1B587568E83CFA32D1F17560C6B9 /* APIRequest.swift */; };
 		52ACFA3C9E48A886A85A392F8932C75B /* Pods-ExampleAppUIKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A42A43C6F41381C47C4892AC4BA2F93 /* Pods-ExampleAppUIKit-dummy.m */; };
-		59CD94B156F83FB983215CBCE128B29B /* ValidationsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF8584C0F4F6E811C565510C3991FC0 /* ValidationsHelper.swift */; };
-		59D2A674A969F79260AAFB66B4DED7BF /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39471A6983694E993792964377AB13C /* SettingsManager.swift */; };
-		68B805CE57ED4D742B7D4B9B528D1CE8 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B0C01689FBF786A98DC5A6700835BA35 /* PrivacyInfo.xcprivacy */; };
-		697686865DB6A6EB83A026D8DDDCA812 /* WidgetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5149BF539FB5ADEE35B17EBD045179E /* WidgetViewController.swift */; };
+		58F40F1567051CAFA9B7369E9EB3032E /* TrustlySDKProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9BD498986985139041ED2D40F08D54F /* TrustlySDKProtocol.swift */; };
+		5D3166B4DAA932CAF2443C4E7081682D /* WidgetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C965DAF27868A2F281863DC06A0DCC23 /* WidgetViewController.swift */; };
+		6460213290F2A54EFAACC9FB08925EEC /* TrustlySDK-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BFE10B8A7AA101CC64C685D6E1AEB04E /* TrustlySDK-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		707CDBDE3052359D53245189D9225E1A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 384DDA2CB25005BD6479B5987C619DD4 /* Foundation.framework */; };
-		711162A1534C9A0A7E36BB027A6059F9 /* LocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7BA888E55ADDF273D6218CBEE7BD8B /* LocalStorage.swift */; };
-		76FAED44E2647011D31EE70141C21869 /* TrustlySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF69C43C04F33247B6AA6540927C64E0 /* TrustlySettings.swift */; };
-		77855DF3AC0A03C12DF93BC488AC6DAB /* TrustlyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A952398FC538EABE9C64FCBE10945168 /* TrustlyService.swift */; };
-		7DE93B8EEDA3CC25BBA4FD7B017406AB /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE30B61459A822981878C7A677105A5 /* String+Extension.swift */; };
-		7ED092A1A7BDA0AE65DEE53C45B92CAF /* LightboxManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C506C238C2971A28447B9313B3604C3 /* LightboxManager.swift */; };
-		7F880B40DC2C5E3B9D92A615D2BEE63F /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6201DFC9AF50C6CCA937F36FB15B492E /* APIRequest.swift */; };
-		8050DA04B33CF68A3BABD8CEB10F4FD6 /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BAB778D9887A498D5B281C900F6F5F /* SessionManager.swift */; };
-		9ABC11EED58CFF6E3B0C1C1DCBD95450 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 384DDA2CB25005BD6479B5987C619DD4 /* Foundation.framework */; };
-		A33B6E4557D61A91DE0A9938FB79C64A /* TrustlySDKProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C6BEBFF756950BFC67FBAE852B7DB6 /* TrustlySDKProtocol.swift */; };
-		B66B61D590EA32659736008FC617F4EF /* JSONUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9F555BDD9F4E52BAA1D58134143599 /* JSONUtils.swift */; };
-		D2FDBAA5AB583C0CB52CA35A2F574591 /* URLUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93477AEBB17313F8B9220CB36D47D8F7 /* URLUtils.swift */; };
-		DA6BE895E4FF81F4A233E5306763E085 /* StorageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD33F43618EA17C38B69D95EE8D66BA2 /* StorageHelper.swift */; };
-		DAC78AB8F6DBDDF44A123C9A1E0D8564 /* TrustlySDK-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C759968E9A122B9869066218F8EB0B27 /* TrustlySDK-dummy.m */; };
-		F0E6409A2B5969F9B59EF3656244521E /* DateHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9683037E2F59E05BD82B2833D03C667E /* DateHelper.swift */; };
-		F1A7122A0736C8CD28A5D14545389DA8 /* LightBoxViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFC26DF9D369C97AA913521360E9505 /* LightBoxViewController.swift */; };
-		F471BD79CCD7B8A3A1F02ECAD403E8E3 /* TrustlyCommonsFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A042B5DBF8C56BDF970B125413E035C1 /* TrustlyCommonsFunctions.swift */; };
-		F76AB63BB536F6877F213E451E33BCCC /* LogUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9058E1A4476EB09F00BA8A4EB59705 /* LogUtils.swift */; };
-		FCE570A5188E92F2C568077BC379EDFA /* DeviceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE95874292E84458D010060AD4AFF05 /* DeviceHelper.swift */; };
+		8AFA6DC49407EA93FB901BF0772BCBFD /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E1E73C286711AD5ADA21258B815A85 /* String+Extension.swift */; };
+		96247108E24163413C2F44C84A9E3910 /* TrustlyEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725C447D61ACF00B338BCF1A6EF2FF47 /* TrustlyEnvironment.swift */; };
+		9BB1630A9C9648D781B1EB1B1E1D5250 /* DateHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19CBED19186ABA7A72E8CAC9D5DB64C /* DateHelper.swift */; };
+		A0F9EC65330E40E4E88B09847CC8DACC /* TrustlySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E4A4171D5EBAAB83A13AA7FEED121B /* TrustlySettings.swift */; };
+		B82A4C8425E4EBF9E0FFB7EC929C68BE /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7F95DF9384117B3EF1B2CC1A1727E1 /* SessionManager.swift */; };
+		BC5C0F2D94FD10F0B95C9FB960A6E02C /* TrustlyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9538C7002F697BB8CEB439397B980203 /* TrustlyService.swift */; };
+		C20001FBD4C91B39B39A1FC20E1692A8 /* NetworkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD51B0FA0A15DBA6B0E1387FFAAA871C /* NetworkHelper.swift */; };
+		C440608EA21BD87BC5A02D7B4E538628 /* LocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790AD5FFE86E377206849D2888D6BC83 /* LocalStorage.swift */; };
+		CC4C1DFA0BFB1B572668C9EE74EE118D /* TrustlySDK-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 51E7C9B1E37A34692A455C8E4648A074 /* TrustlySDK-dummy.m */; };
+		D4B4F2856A3C0FE1248B1C967AD03F95 /* LogUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F137EFA2E37FF408349AE293F7DB1321 /* LogUtils.swift */; };
+		D69A784EFCC56BA8C92F3AD2ADCDCF6E /* EstablishDataUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA9314EB99570714A724824DB0EE694 /* EstablishDataUtils.swift */; };
+		E16B981FB64A2D486EF4279A23265332 /* LightboxManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A886A24E94861E7F6959087692C884 /* LightboxManager.swift */; };
+		E218D9A857E34251F17E9F1EEC2C2E6C /* LightBoxViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BFD6426F3C1F5AECDCB933821EDA58 /* LightBoxViewController.swift */; };
+		E347BFEAC97AAD8563BFD590BF6B20E5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 384DDA2CB25005BD6479B5987C619DD4 /* Foundation.framework */; };
+		E6E63C1D4164C88BADB9FFBBA50E29C5 /* AnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A667133B8C7F760017C1E57EF816D2 /* AnalyticsHelper.swift */; };
+		E9F02507023424B6D2F7097741B85C81 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A591E1812EE82F370263DA9F39AF77 /* SettingsManager.swift */; };
+		FBCC4D4B0C958F7DB3093156F1808F70 /* DeviceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FD7A51A83B9603FD171ECA830C2056 /* DeviceHelper.swift */; };
+		FCCFC74C62F0011ECD16E19D1D61981C /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = C8B0B97F2D8282C4AAAA36B1A5421756 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		8E88BDE303F36F09A2055B861BD1B8E7 /* PBXContainerItemProxy */ = {
+		1601B22D308E681D35EE24978F6D0F8D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
@@ -52,64 +53,65 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1AC79658B0DE0FAB243DCA2D7C45F19A /* TrustlySDK.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = TrustlySDK.modulemap; sourceTree = "<group>"; };
+		0FCC1B587568E83CFA32D1F17560C6B9 /* APIRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
 		2163B5964DA5EB8E7A8C9CE4152BA66A /* Pods-ExampleAppUIKit */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-ExampleAppUIKit"; path = Pods_ExampleAppUIKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		21FAA3E7669E55061D067402A7E8B50C /* TrustlySDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = TrustlySDK.debug.xcconfig; sourceTree = "<group>"; };
-		221FB9A01DC011B692286676A37FB0D1 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
-		225A74AD1FB5CE5DBD05F3655A4B076A /* AnalyticsHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnalyticsHelper.swift; sourceTree = "<group>"; };
 		2A42A43C6F41381C47C4892AC4BA2F93 /* Pods-ExampleAppUIKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-ExampleAppUIKit-dummy.m"; sourceTree = "<group>"; };
 		2F79DA45AC1013D3A7AE35AB2CA94CB9 /* Pods-ExampleAppUIKit-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-ExampleAppUIKit-frameworks.sh"; sourceTree = "<group>"; };
+		31FD7A51A83B9603FD171ECA830C2056 /* DeviceHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeviceHelper.swift; sourceTree = "<group>"; };
+		324D9EF3D4A7CCBEC282F1A4A2C7FD83 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
 		384DDA2CB25005BD6479B5987C619DD4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		3896209482EEE4044A326C9941AE09F4 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
 		40822F7DCB34A242DEE906D97868EE35 /* Pods-ExampleAppUIKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-ExampleAppUIKit-Info.plist"; sourceTree = "<group>"; };
 		4797694AA3ECCF8394F6CAF25CB7A00E /* TrustlySDK */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = TrustlySDK; path = TrustlySDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		53BAB778D9887A498D5B281C900F6F5F /* SessionManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
-		5C506C238C2971A28447B9313B3604C3 /* LightboxManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightboxManager.swift; sourceTree = "<group>"; };
-		5D9F555BDD9F4E52BAA1D58134143599 /* JSONUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JSONUtils.swift; sourceTree = "<group>"; };
-		5FD34BD7EAB7C0F5D1391C73D8D53585 /* EstablishDataUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EstablishDataUtils.swift; sourceTree = "<group>"; };
-		6155BAC4C983E0E5344DFA04C4DFB2A7 /* WebViewManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewManager.swift; sourceTree = "<group>"; };
-		6201DFC9AF50C6CCA937F36FB15B492E /* APIRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
-		6CE30B61459A822981878C7A677105A5 /* String+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
-		7C148CD5265E0F76419F12A0EF85C0E2 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		7CE95874292E84458D010060AD4AFF05 /* DeviceHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeviceHelper.swift; sourceTree = "<group>"; };
-		7D0D52A1692707CF914C9E5620AED1FA /* TrustlySDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "TrustlySDK-Info.plist"; sourceTree = "<group>"; };
-		7D7BA888E55ADDF273D6218CBEE7BD8B /* LocalStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalStorage.swift; sourceTree = "<group>"; };
-		7F3CC29624818F3541C5B693E029754D /* NetworkHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkHelper.swift; sourceTree = "<group>"; };
-		87E2CF5874763E8909E33B24952815A0 /* TrustlySDK.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TrustlySDK.swift; path = TrustlySDK/TrustlySDK/TrustlySDK.swift; sourceTree = "<group>"; };
-		8D0B9170083A9CF640A5A3110E2C22BB /* swift_package_manager.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = swift_package_manager.png; path = docs/images/swift_package_manager.png; sourceTree = "<group>"; };
+		4C19C13ED34A9C10BF1E69F676FDE97D /* TrustlySDK.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = TrustlySDK.modulemap; sourceTree = "<group>"; };
+		50BFD6426F3C1F5AECDCB933821EDA58 /* LightBoxViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightBoxViewController.swift; sourceTree = "<group>"; };
+		51E7C9B1E37A34692A455C8E4648A074 /* TrustlySDK-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "TrustlySDK-dummy.m"; sourceTree = "<group>"; };
+		5CA9C98396D91AF707AFE8AAE91696BD /* TrustlySDK.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TrustlySDK.swift; path = TrustlySDK/TrustlySDK/TrustlySDK.swift; sourceTree = "<group>"; };
+		725C447D61ACF00B338BCF1A6EF2FF47 /* TrustlyEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrustlyEnvironment.swift; sourceTree = "<group>"; };
+		77E4A4171D5EBAAB83A13AA7FEED121B /* TrustlySettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrustlySettings.swift; sourceTree = "<group>"; };
+		790AD5FFE86E377206849D2888D6BC83 /* LocalStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalStorage.swift; sourceTree = "<group>"; };
+		7BA9314EB99570714A724824DB0EE694 /* EstablishDataUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EstablishDataUtils.swift; sourceTree = "<group>"; };
 		8D3316A6DA56A23B7A361EFF4050D6A9 /* Pods-ExampleAppUIKit-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-ExampleAppUIKit-acknowledgements.plist"; sourceTree = "<group>"; };
-		8E07697205018102D79427E90C174683 /* TrustlySDK-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TrustlySDK-prefix.pch"; sourceTree = "<group>"; };
-		93477AEBB17313F8B9220CB36D47D8F7 /* URLUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLUtils.swift; sourceTree = "<group>"; };
-		9683037E2F59E05BD82B2833D03C667E /* DateHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DateHelper.swift; sourceTree = "<group>"; };
-		9B2E19B944CD9E6BB76FB2C829EAE6A7 /* TrustlySDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = TrustlySDK.release.xcconfig; sourceTree = "<group>"; };
+		9538C7002F697BB8CEB439397B980203 /* TrustlyService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrustlyService.swift; sourceTree = "<group>"; };
+		97A886A24E94861E7F6959087692C884 /* LightboxManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightboxManager.swift; sourceTree = "<group>"; };
+		9A53C65C0665CD7232235750F72574D9 /* TrustlySDK-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TrustlySDK-prefix.pch"; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		A042B5DBF8C56BDF970B125413E035C1 /* TrustlyCommonsFunctions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrustlyCommonsFunctions.swift; sourceTree = "<group>"; };
 		A25FF4A27FCAB8131058756D28D31847 /* Pods-ExampleAppUIKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-ExampleAppUIKit-umbrella.h"; sourceTree = "<group>"; };
-		A5149BF539FB5ADEE35B17EBD045179E /* WidgetViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetViewController.swift; sourceTree = "<group>"; };
-		A952398FC538EABE9C64FCBE10945168 /* TrustlyService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrustlyService.swift; sourceTree = "<group>"; };
-		AA2FDC814DE3AA89DEB599B9418ED2F9 /* TrustlySDK.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = TrustlySDK.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		AA291934F49A73472AE9DD870B7C8F8C /* TrustlySDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = TrustlySDK.release.xcconfig; sourceTree = "<group>"; };
+		ABDFD55D45233E2144B4D243B7B5C75A /* TrustlyCommonsFunctions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrustlyCommonsFunctions.swift; sourceTree = "<group>"; };
 		AFE99C956ECD110F140E013549192E63 /* Pods-ExampleAppUIKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-ExampleAppUIKit.modulemap"; sourceTree = "<group>"; };
-		B0C01689FBF786A98DC5A6700835BA35 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = TrustlySDK/TrustlySDK/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		BC18967D9587E8CC442AFB7F77C3B06C /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		B3A591E1812EE82F370263DA9F39AF77 /* SettingsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
+		B3F9722FDA29DBFE370A346CFC4CCBDF /* TrustlySDK.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = TrustlySDK.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		B7EEE1FAAD1B97BC5BC4CD10E62B64F7 /* JSONUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JSONUtils.swift; sourceTree = "<group>"; };
 		BCAFE3A2A24DF1C78F2ED141BEFFC392 /* Pods-ExampleAppUIKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ExampleAppUIKit.release.xcconfig"; sourceTree = "<group>"; };
 		BEF3E6DADA7908967B8286CC995B98BB /* Pods-ExampleAppUIKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ExampleAppUIKit.debug.xcconfig"; sourceTree = "<group>"; };
-		C5F463FA0D7C51B067DACAD856B70792 /* TrustlySDK-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TrustlySDK-umbrella.h"; sourceTree = "<group>"; };
-		C759968E9A122B9869066218F8EB0B27 /* TrustlySDK-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "TrustlySDK-dummy.m"; sourceTree = "<group>"; };
+		BFE10B8A7AA101CC64C685D6E1AEB04E /* TrustlySDK-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TrustlySDK-umbrella.h"; sourceTree = "<group>"; };
+		C59B72B9AAB4CB7C2529651C8D612DFC /* TrustlySDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "TrustlySDK-Info.plist"; sourceTree = "<group>"; };
+		C8A667133B8C7F760017C1E57EF816D2 /* AnalyticsHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnalyticsHelper.swift; sourceTree = "<group>"; };
+		C8B0B97F2D8282C4AAAA36B1A5421756 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = TrustlySDK/TrustlySDK/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		C8F19136391CACBEA5F8B2C040DE6A8E /* StorageHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StorageHelper.swift; sourceTree = "<group>"; };
+		C965DAF27868A2F281863DC06A0DCC23 /* WidgetViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetViewController.swift; sourceTree = "<group>"; };
 		CAC28836A6EAA35173167CC8D1830784 /* Pods-ExampleAppUIKit-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-ExampleAppUIKit-acknowledgements.markdown"; sourceTree = "<group>"; };
-		CEFC26DF9D369C97AA913521360E9505 /* LightBoxViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightBoxViewController.swift; sourceTree = "<group>"; };
-		CF9058E1A4476EB09F00BA8A4EB59705 /* LogUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LogUtils.swift; sourceTree = "<group>"; };
-		D39471A6983694E993792964377AB13C /* SettingsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
-		DD33F43618EA17C38B69D95EE8D66BA2 /* StorageHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StorageHelper.swift; sourceTree = "<group>"; };
-		DDF8584C0F4F6E811C565510C3991FC0 /* ValidationsHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ValidationsHelper.swift; sourceTree = "<group>"; };
-		F6C6BEBFF756950BFC67FBAE852B7DB6 /* TrustlySDKProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TrustlySDKProtocol.swift; path = TrustlySDK/TrustlySDK/TrustlySDKProtocol.swift; sourceTree = "<group>"; };
-		FF69C43C04F33247B6AA6540927C64E0 /* TrustlySettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrustlySettings.swift; sourceTree = "<group>"; };
+		CECFA95ECACDE8BAABE66F1873BB2949 /* swift_package_manager.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = swift_package_manager.png; path = docs/images/swift_package_manager.png; sourceTree = "<group>"; };
+		D3EC4320181D7775B736B77B2448782F /* URLUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLUtils.swift; sourceTree = "<group>"; };
+		D86EABDB9B14918E48D65751FFA93ADE /* WebViewManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewManager.swift; sourceTree = "<group>"; };
+		D9BD498986985139041ED2D40F08D54F /* TrustlySDKProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TrustlySDKProtocol.swift; path = TrustlySDK/TrustlySDK/TrustlySDKProtocol.swift; sourceTree = "<group>"; };
+		DB0126BCBD080EBC363387D66F620939 /* TrustlySDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = TrustlySDK.debug.xcconfig; sourceTree = "<group>"; };
+		E19CBED19186ABA7A72E8CAC9D5DB64C /* DateHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DateHelper.swift; sourceTree = "<group>"; };
+		E9E1E73C286711AD5ADA21258B815A85 /* String+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
+		EA3994B4F29B69A7FEE96E1A30C61221 /* ValidationsHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ValidationsHelper.swift; sourceTree = "<group>"; };
+		ED7F95DF9384117B3EF1B2CC1A1727E1 /* SessionManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
+		F137EFA2E37FF408349AE293F7DB1321 /* LogUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LogUtils.swift; sourceTree = "<group>"; };
+		F954BC40C074CF002FD863B828715858 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		FD51B0FA0A15DBA6B0E1387FFAAA871C /* NetworkHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		098DA549AB098FC0A7F8B43C5B160D3B /* Frameworks */ = {
+		2F05E1B0F7D3D80C97025F8C00F5978B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9ABC11EED58CFF6E3B0C1C1DCBD95450 /* Foundation.framework in Frameworks */,
+				E347BFEAC97AAD8563BFD590BF6B20E5 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -124,97 +126,140 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		05D1B8386DC96A1D76B13F544EFF98E3 /* Webview */ = {
+		0985749C744B7C7370AC1562C85849BC /* Session */ = {
 			isa = PBXGroup;
 			children = (
-				6155BAC4C983E0E5344DFA04C4DFB2A7 /* WebViewManager.swift */,
-			);
-			name = Webview;
-			path = TrustlySDK/TrustlySDK/Webview;
-			sourceTree = "<group>";
-		};
-		0C18BA37012199A3EA18DA74AF59C7CE /* Controller */ = {
-			isa = PBXGroup;
-			children = (
-				CEFC26DF9D369C97AA913521360E9505 /* LightBoxViewController.swift */,
-				A5149BF539FB5ADEE35B17EBD045179E /* WidgetViewController.swift */,
-			);
-			name = Controller;
-			path = TrustlySDK/TrustlySDK/Controller;
-			sourceTree = "<group>";
-		};
-		2A2246BF1FF990D421E212C198DA3198 /* TrustlySDK */ = {
-			isa = PBXGroup;
-			children = (
-				B0C01689FBF786A98DC5A6700835BA35 /* PrivacyInfo.xcprivacy */,
-				87E2CF5874763E8909E33B24952815A0 /* TrustlySDK.swift */,
-				F6C6BEBFF756950BFC67FBAE852B7DB6 /* TrustlySDKProtocol.swift */,
-				C0C9981468DEC4A6E7FDB33AE2E1EE98 /* Commons */,
-				0C18BA37012199A3EA18DA74AF59C7CE /* Controller */,
-				DDC60C4F06BBEA5FC28CDBE899BE7213 /* Extensions */,
-				883D7205C0CCDC376E4E42E67A700537 /* Helpers */,
-				5D592E4F7A0D42109A537749F64AC7A6 /* Lightbox */,
-				FB1A1A7E51F2437743DDF730739A99A6 /* Network */,
-				A3DB4FEF9FE231CD1B063264FD838491 /* Pod */,
-				8CFC787A886AAEC79B339620F2F87496 /* Repository */,
-				E48B63A40F844E60E72D4B340FBB7CE4 /* Services */,
-				63016E3EB72B8D76D984F59566AD6A7E /* Session */,
-				FBDBC40C03E8B71A4A8F207F5EB1CD1E /* Settings */,
-				982CF0E2B46666C158CFA303EC1BA207 /* Support Files */,
-				B822DE8F4242381608663F69D6A7BA2D /* Utils */,
-				05D1B8386DC96A1D76B13F544EFF98E3 /* Webview */,
-			);
-			name = TrustlySDK;
-			path = ../../..;
-			sourceTree = "<group>";
-		};
-		5D592E4F7A0D42109A537749F64AC7A6 /* Lightbox */ = {
-			isa = PBXGroup;
-			children = (
-				5C506C238C2971A28447B9313B3604C3 /* LightboxManager.swift */,
-			);
-			name = Lightbox;
-			path = TrustlySDK/TrustlySDK/Lightbox;
-			sourceTree = "<group>";
-		};
-		63016E3EB72B8D76D984F59566AD6A7E /* Session */ = {
-			isa = PBXGroup;
-			children = (
-				53BAB778D9887A498D5B281C900F6F5F /* SessionManager.swift */,
+				ED7F95DF9384117B3EF1B2CC1A1727E1 /* SessionManager.swift */,
 			);
 			name = Session;
 			path = TrustlySDK/TrustlySDK/Session;
 			sourceTree = "<group>";
 		};
-		858A642EDA983F4878851F1C7742F604 /* Development Pods */ = {
+		10CAC35A82784ACDD681C15FCFC8D1BE /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				2A2246BF1FF990D421E212C198DA3198 /* TrustlySDK */,
+				F954BC40C074CF002FD863B828715858 /* Constants.swift */,
+				7BA9314EB99570714A724824DB0EE694 /* EstablishDataUtils.swift */,
+				B7EEE1FAAD1B97BC5BC4CD10E62B64F7 /* JSONUtils.swift */,
+				F137EFA2E37FF408349AE293F7DB1321 /* LogUtils.swift */,
+				725C447D61ACF00B338BCF1A6EF2FF47 /* TrustlyEnvironment.swift */,
+				D3EC4320181D7775B736B77B2448782F /* URLUtils.swift */,
 			);
-			name = "Development Pods";
+			name = Utils;
+			path = TrustlySDK/TrustlySDK/Utils;
 			sourceTree = "<group>";
 		};
-		883D7205C0CCDC376E4E42E67A700537 /* Helpers */ = {
+		1B6B5794D4979038BC7573FE2C04C647 /* Network */ = {
 			isa = PBXGroup;
 			children = (
-				225A74AD1FB5CE5DBD05F3655A4B076A /* AnalyticsHelper.swift */,
-				9683037E2F59E05BD82B2833D03C667E /* DateHelper.swift */,
-				7CE95874292E84458D010060AD4AFF05 /* DeviceHelper.swift */,
-				7F3CC29624818F3541C5B693E029754D /* NetworkHelper.swift */,
-				DD33F43618EA17C38B69D95EE8D66BA2 /* StorageHelper.swift */,
-				DDF8584C0F4F6E811C565510C3991FC0 /* ValidationsHelper.swift */,
+				0FCC1B587568E83CFA32D1F17560C6B9 /* APIRequest.swift */,
+			);
+			name = Network;
+			path = TrustlySDK/TrustlySDK/Network;
+			sourceTree = "<group>";
+		};
+		1D85BA273BE6D247945E0284198F0B48 /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				790AD5FFE86E377206849D2888D6BC83 /* LocalStorage.swift */,
+			);
+			name = Repository;
+			path = TrustlySDK/TrustlySDK/Repository;
+			sourceTree = "<group>";
+		};
+		27074E94780EEDB94543FE4E99ECCB48 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				E9E1E73C286711AD5ADA21258B815A85 /* String+Extension.swift */,
+			);
+			name = Extensions;
+			path = TrustlySDK/TrustlySDK/Extensions;
+			sourceTree = "<group>";
+		};
+		306EEDC6C3517DA8CF7F31DEF9558B9B /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				9538C7002F697BB8CEB439397B980203 /* TrustlyService.swift */,
+			);
+			name = Services;
+			path = TrustlySDK/TrustlySDK/Services;
+			sourceTree = "<group>";
+		};
+		41A8FD8274D7897DAEDADDCFF0003BB0 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				B3A591E1812EE82F370263DA9F39AF77 /* SettingsManager.swift */,
+				77E4A4171D5EBAAB83A13AA7FEED121B /* TrustlySettings.swift */,
+			);
+			name = Settings;
+			path = TrustlySDK/TrustlySDK/Settings;
+			sourceTree = "<group>";
+		};
+		4B49F20824B086FE0ACEC87EFC0253A0 /* Controller */ = {
+			isa = PBXGroup;
+			children = (
+				50BFD6426F3C1F5AECDCB933821EDA58 /* LightBoxViewController.swift */,
+				C965DAF27868A2F281863DC06A0DCC23 /* WidgetViewController.swift */,
+			);
+			name = Controller;
+			path = TrustlySDK/TrustlySDK/Controller;
+			sourceTree = "<group>";
+		};
+		5D715E23F385D64172D763EF24A95306 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				3896209482EEE4044A326C9941AE09F4 /* LICENSE */,
+				324D9EF3D4A7CCBEC282F1A4A2C7FD83 /* README.md */,
+				CECFA95ECACDE8BAABE66F1873BB2949 /* swift_package_manager.png */,
+				B3F9722FDA29DBFE370A346CFC4CCBDF /* TrustlySDK.podspec */,
+			);
+			name = Pod;
+			sourceTree = "<group>";
+		};
+		66E67B332872DAD6C54DF1B5EC3ED8AA /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				4C19C13ED34A9C10BF1E69F676FDE97D /* TrustlySDK.modulemap */,
+				51E7C9B1E37A34692A455C8E4648A074 /* TrustlySDK-dummy.m */,
+				C59B72B9AAB4CB7C2529651C8D612DFC /* TrustlySDK-Info.plist */,
+				9A53C65C0665CD7232235750F72574D9 /* TrustlySDK-prefix.pch */,
+				BFE10B8A7AA101CC64C685D6E1AEB04E /* TrustlySDK-umbrella.h */,
+				DB0126BCBD080EBC363387D66F620939 /* TrustlySDK.debug.xcconfig */,
+				AA291934F49A73472AE9DD870B7C8F8C /* TrustlySDK.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "ExampleApp/ExampleAppUIKit/Pods/Target Support Files/TrustlySDK";
+			sourceTree = "<group>";
+		};
+		7533869F2E136637B7CE3B0E894FDB15 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				C8A667133B8C7F760017C1E57EF816D2 /* AnalyticsHelper.swift */,
+				E19CBED19186ABA7A72E8CAC9D5DB64C /* DateHelper.swift */,
+				31FD7A51A83B9603FD171ECA830C2056 /* DeviceHelper.swift */,
+				FD51B0FA0A15DBA6B0E1387FFAAA871C /* NetworkHelper.swift */,
+				C8F19136391CACBEA5F8B2C040DE6A8E /* StorageHelper.swift */,
+				EA3994B4F29B69A7FEE96E1A30C61221 /* ValidationsHelper.swift */,
 			);
 			name = Helpers;
 			path = TrustlySDK/TrustlySDK/Helpers;
 			sourceTree = "<group>";
 		};
-		8CFC787A886AAEC79B339620F2F87496 /* Repository */ = {
+		7AF5F3A0ABA6B1C92FB9DB702F483CB4 /* Lightbox */ = {
 			isa = PBXGroup;
 			children = (
-				7D7BA888E55ADDF273D6218CBEE7BD8B /* LocalStorage.swift */,
+				97A886A24E94861E7F6959087692C884 /* LightboxManager.swift */,
 			);
-			name = Repository;
-			path = TrustlySDK/TrustlySDK/Repository;
+			name = Lightbox;
+			path = TrustlySDK/TrustlySDK/Lightbox;
+			sourceTree = "<group>";
+		};
+		858A642EDA983F4878851F1C7742F604 /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				BAF79BE071D60A3AF50FF1E07AC08591 /* TrustlySDK */,
+			);
+			name = "Development Pods";
 			sourceTree = "<group>";
 		};
 		8D6C7FF4076CD2C4C9232907010FBE3F /* Pods-ExampleAppUIKit */ = {
@@ -234,32 +279,6 @@
 			path = "Target Support Files/Pods-ExampleAppUIKit";
 			sourceTree = "<group>";
 		};
-		982CF0E2B46666C158CFA303EC1BA207 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				1AC79658B0DE0FAB243DCA2D7C45F19A /* TrustlySDK.modulemap */,
-				C759968E9A122B9869066218F8EB0B27 /* TrustlySDK-dummy.m */,
-				7D0D52A1692707CF914C9E5620AED1FA /* TrustlySDK-Info.plist */,
-				8E07697205018102D79427E90C174683 /* TrustlySDK-prefix.pch */,
-				C5F463FA0D7C51B067DACAD856B70792 /* TrustlySDK-umbrella.h */,
-				21FAA3E7669E55061D067402A7E8B50C /* TrustlySDK.debug.xcconfig */,
-				9B2E19B944CD9E6BB76FB2C829EAE6A7 /* TrustlySDK.release.xcconfig */,
-			);
-			name = "Support Files";
-			path = "ExampleApp/ExampleAppUIKit/Pods/Target Support Files/TrustlySDK";
-			sourceTree = "<group>";
-		};
-		A3DB4FEF9FE231CD1B063264FD838491 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				BC18967D9587E8CC442AFB7F77C3B06C /* LICENSE */,
-				221FB9A01DC011B692286676A37FB0D1 /* README.md */,
-				8D0B9170083A9CF640A5A3110E2C22BB /* swift_package_manager.png */,
-				AA2FDC814DE3AA89DEB599B9418ED2F9 /* TrustlySDK.podspec */,
-			);
-			name = Pod;
-			sourceTree = "<group>";
-		};
 		B18C92AB1339F24695C54E6107EF4ADD /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -269,26 +288,29 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		B822DE8F4242381608663F69D6A7BA2D /* Utils */ = {
+		BAF79BE071D60A3AF50FF1E07AC08591 /* TrustlySDK */ = {
 			isa = PBXGroup;
 			children = (
-				7C148CD5265E0F76419F12A0EF85C0E2 /* Constants.swift */,
-				5FD34BD7EAB7C0F5D1391C73D8D53585 /* EstablishDataUtils.swift */,
-				5D9F555BDD9F4E52BAA1D58134143599 /* JSONUtils.swift */,
-				CF9058E1A4476EB09F00BA8A4EB59705 /* LogUtils.swift */,
-				93477AEBB17313F8B9220CB36D47D8F7 /* URLUtils.swift */,
+				C8B0B97F2D8282C4AAAA36B1A5421756 /* PrivacyInfo.xcprivacy */,
+				5CA9C98396D91AF707AFE8AAE91696BD /* TrustlySDK.swift */,
+				D9BD498986985139041ED2D40F08D54F /* TrustlySDKProtocol.swift */,
+				DC9C931172AC21601CE801B0913C8326 /* Commons */,
+				4B49F20824B086FE0ACEC87EFC0253A0 /* Controller */,
+				27074E94780EEDB94543FE4E99ECCB48 /* Extensions */,
+				7533869F2E136637B7CE3B0E894FDB15 /* Helpers */,
+				7AF5F3A0ABA6B1C92FB9DB702F483CB4 /* Lightbox */,
+				1B6B5794D4979038BC7573FE2C04C647 /* Network */,
+				5D715E23F385D64172D763EF24A95306 /* Pod */,
+				1D85BA273BE6D247945E0284198F0B48 /* Repository */,
+				306EEDC6C3517DA8CF7F31DEF9558B9B /* Services */,
+				0985749C744B7C7370AC1562C85849BC /* Session */,
+				41A8FD8274D7897DAEDADDCFF0003BB0 /* Settings */,
+				66E67B332872DAD6C54DF1B5EC3ED8AA /* Support Files */,
+				10CAC35A82784ACDD681C15FCFC8D1BE /* Utils */,
+				F42887B302DD219A5EE6234906DE2FF6 /* Webview */,
 			);
-			name = Utils;
-			path = TrustlySDK/TrustlySDK/Utils;
-			sourceTree = "<group>";
-		};
-		C0C9981468DEC4A6E7FDB33AE2E1EE98 /* Commons */ = {
-			isa = PBXGroup;
-			children = (
-				A042B5DBF8C56BDF970B125413E035C1 /* TrustlyCommonsFunctions.swift */,
-			);
-			name = Commons;
-			path = TrustlySDK/TrustlySDK/Commons;
+			name = TrustlySDK;
+			path = ../../..;
 			sourceTree = "<group>";
 		};
 		CF1408CF629C7361332E53B88F7BD30C = {
@@ -310,13 +332,13 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		DDC60C4F06BBEA5FC28CDBE899BE7213 /* Extensions */ = {
+		DC9C931172AC21601CE801B0913C8326 /* Commons */ = {
 			isa = PBXGroup;
 			children = (
-				6CE30B61459A822981878C7A677105A5 /* String+Extension.swift */,
+				ABDFD55D45233E2144B4D243B7B5C75A /* TrustlyCommonsFunctions.swift */,
 			);
-			name = Extensions;
-			path = TrustlySDK/TrustlySDK/Extensions;
+			name = Commons;
+			path = TrustlySDK/TrustlySDK/Commons;
 			sourceTree = "<group>";
 		};
 		E4801F62A6B08CD9B5410329F1A18FDE /* iOS */ = {
@@ -327,15 +349,6 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		E48B63A40F844E60E72D4B340FBB7CE4 /* Services */ = {
-			isa = PBXGroup;
-			children = (
-				A952398FC538EABE9C64FCBE10945168 /* TrustlyService.swift */,
-			);
-			name = Services;
-			path = TrustlySDK/TrustlySDK/Services;
-			sourceTree = "<group>";
-		};
 		E6E8E2305C4A79EF5F17A3F0752D1CDE /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -344,23 +357,13 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		FB1A1A7E51F2437743DDF730739A99A6 /* Network */ = {
+		F42887B302DD219A5EE6234906DE2FF6 /* Webview */ = {
 			isa = PBXGroup;
 			children = (
-				6201DFC9AF50C6CCA937F36FB15B492E /* APIRequest.swift */,
+				D86EABDB9B14918E48D65751FFA93ADE /* WebViewManager.swift */,
 			);
-			name = Network;
-			path = TrustlySDK/TrustlySDK/Network;
-			sourceTree = "<group>";
-		};
-		FBDBC40C03E8B71A4A8F207F5EB1CD1E /* Settings */ = {
-			isa = PBXGroup;
-			children = (
-				D39471A6983694E993792964377AB13C /* SettingsManager.swift */,
-				FF69C43C04F33247B6AA6540927C64E0 /* TrustlySettings.swift */,
-			);
-			name = Settings;
-			path = TrustlySDK/TrustlySDK/Settings;
+			name = Webview;
+			path = TrustlySDK/TrustlySDK/Webview;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -374,11 +377,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4FAB683B5C55567DB6261C62081DB03D /* Headers */ = {
+		B47027627B46F889AA550E4CC4F2FAC3 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1C060B67D5186C0FF7CED428BF2E4AE6 /* TrustlySDK-umbrella.h in Headers */,
+				6460213290F2A54EFAACC9FB08925EEC /* TrustlySDK-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -397,7 +400,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				5F932BD799BCCCFB7BF7E370237F8BBB /* PBXTargetDependency */,
+				504678A8EFF8436B24669BB6CC15995A /* PBXTargetDependency */,
 			);
 			name = "Pods-ExampleAppUIKit";
 			productName = Pods_ExampleAppUIKit;
@@ -406,12 +409,12 @@
 		};
 		77127F2B80807CFC98D2D2E894F9051C /* TrustlySDK */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 7237AA44895F9C965AEAC0A07BD50754 /* Build configuration list for PBXNativeTarget "TrustlySDK" */;
+			buildConfigurationList = A0EF0EC2604E90442E3158A0ED2D6CDF /* Build configuration list for PBXNativeTarget "TrustlySDK" */;
 			buildPhases = (
-				4FAB683B5C55567DB6261C62081DB03D /* Headers */,
-				578239364FD128962882FA590ED97272 /* Sources */,
-				098DA549AB098FC0A7F8B43C5B160D3B /* Frameworks */,
-				A2AEF918D306AD7FD9118AFBF85A8295 /* Resources */,
+				B47027627B46F889AA550E4CC4F2FAC3 /* Headers */,
+				A5942F18017CB7EEDF92D863F965241F /* Sources */,
+				2F05E1B0F7D3D80C97025F8C00F5978B /* Frameworks */,
+				43A23688C68527F43B6BFC1BBBC999F0 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -453,11 +456,11 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		A2AEF918D306AD7FD9118AFBF85A8295 /* Resources */ = {
+		43A23688C68527F43B6BFC1BBBC999F0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				68B805CE57ED4D742B7D4B9B528D1CE8 /* PrivacyInfo.xcprivacy in Resources */,
+				FCCFC74C62F0011ECD16E19D1D61981C /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -471,36 +474,37 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		578239364FD128962882FA590ED97272 /* Sources */ = {
+		A5942F18017CB7EEDF92D863F965241F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0DD83A7639F3D4E3D874BBCD3F854B1E /* AnalyticsHelper.swift in Sources */,
-				7F880B40DC2C5E3B9D92A615D2BEE63F /* APIRequest.swift in Sources */,
-				257A30DA1045CD0C398DC820C13587C3 /* Constants.swift in Sources */,
-				F0E6409A2B5969F9B59EF3656244521E /* DateHelper.swift in Sources */,
-				FCE570A5188E92F2C568077BC379EDFA /* DeviceHelper.swift in Sources */,
-				246039C1651D6BB3BD151899ADB7B62C /* EstablishDataUtils.swift in Sources */,
-				B66B61D590EA32659736008FC617F4EF /* JSONUtils.swift in Sources */,
-				7ED092A1A7BDA0AE65DEE53C45B92CAF /* LightboxManager.swift in Sources */,
-				F1A7122A0736C8CD28A5D14545389DA8 /* LightBoxViewController.swift in Sources */,
-				711162A1534C9A0A7E36BB027A6059F9 /* LocalStorage.swift in Sources */,
-				F76AB63BB536F6877F213E451E33BCCC /* LogUtils.swift in Sources */,
-				1DE379A837BABE47F2E1BBC5E13605DA /* NetworkHelper.swift in Sources */,
-				8050DA04B33CF68A3BABD8CEB10F4FD6 /* SessionManager.swift in Sources */,
-				59D2A674A969F79260AAFB66B4DED7BF /* SettingsManager.swift in Sources */,
-				DA6BE895E4FF81F4A233E5306763E085 /* StorageHelper.swift in Sources */,
-				7DE93B8EEDA3CC25BBA4FD7B017406AB /* String+Extension.swift in Sources */,
-				F471BD79CCD7B8A3A1F02ECAD403E8E3 /* TrustlyCommonsFunctions.swift in Sources */,
-				1797D16862A2DBB4082D491EC73E92F4 /* TrustlySDK.swift in Sources */,
-				DAC78AB8F6DBDDF44A123C9A1E0D8564 /* TrustlySDK-dummy.m in Sources */,
-				A33B6E4557D61A91DE0A9938FB79C64A /* TrustlySDKProtocol.swift in Sources */,
-				77855DF3AC0A03C12DF93BC488AC6DAB /* TrustlyService.swift in Sources */,
-				76FAED44E2647011D31EE70141C21869 /* TrustlySettings.swift in Sources */,
-				D2FDBAA5AB583C0CB52CA35A2F574591 /* URLUtils.swift in Sources */,
-				59CD94B156F83FB983215CBCE128B29B /* ValidationsHelper.swift in Sources */,
-				2CED90DC88249AB8CE0610872D2E867E /* WebViewManager.swift in Sources */,
-				697686865DB6A6EB83A026D8DDDCA812 /* WidgetViewController.swift in Sources */,
+				E6E63C1D4164C88BADB9FFBBA50E29C5 /* AnalyticsHelper.swift in Sources */,
+				515C37EF24FDD2E153196AFA96940A1B /* APIRequest.swift in Sources */,
+				2369B032E477C98B41AA53BB82421FF4 /* Constants.swift in Sources */,
+				9BB1630A9C9648D781B1EB1B1E1D5250 /* DateHelper.swift in Sources */,
+				FBCC4D4B0C958F7DB3093156F1808F70 /* DeviceHelper.swift in Sources */,
+				D69A784EFCC56BA8C92F3AD2ADCDCF6E /* EstablishDataUtils.swift in Sources */,
+				13A4741F461AA8592EF9BDFFB38A0C94 /* JSONUtils.swift in Sources */,
+				E16B981FB64A2D486EF4279A23265332 /* LightboxManager.swift in Sources */,
+				E218D9A857E34251F17E9F1EEC2C2E6C /* LightBoxViewController.swift in Sources */,
+				C440608EA21BD87BC5A02D7B4E538628 /* LocalStorage.swift in Sources */,
+				D4B4F2856A3C0FE1248B1C967AD03F95 /* LogUtils.swift in Sources */,
+				C20001FBD4C91B39B39A1FC20E1692A8 /* NetworkHelper.swift in Sources */,
+				B82A4C8425E4EBF9E0FFB7EC929C68BE /* SessionManager.swift in Sources */,
+				E9F02507023424B6D2F7097741B85C81 /* SettingsManager.swift in Sources */,
+				1CDF2C71D457F389825311F2F75FD98D /* StorageHelper.swift in Sources */,
+				8AFA6DC49407EA93FB901BF0772BCBFD /* String+Extension.swift in Sources */,
+				1CFD157C06A26F21022C3351018FA7A5 /* TrustlyCommonsFunctions.swift in Sources */,
+				96247108E24163413C2F44C84A9E3910 /* TrustlyEnvironment.swift in Sources */,
+				236485AAD27495A4A8BD45CC47DD66AC /* TrustlySDK.swift in Sources */,
+				CC4C1DFA0BFB1B572668C9EE74EE118D /* TrustlySDK-dummy.m in Sources */,
+				58F40F1567051CAFA9B7369E9EB3032E /* TrustlySDKProtocol.swift in Sources */,
+				BC5C0F2D94FD10F0B95C9FB960A6E02C /* TrustlyService.swift in Sources */,
+				A0F9EC65330E40E4E88B09847CC8DACC /* TrustlySettings.swift in Sources */,
+				47135613CF8B787092A308DC5F38604F /* URLUtils.swift in Sources */,
+				0044B2EA3E355ACC33AED6BE14CBBDFA /* ValidationsHelper.swift in Sources */,
+				503F604855E8A3034EEDBAA1723FC716 /* WebViewManager.swift in Sources */,
+				5D3166B4DAA932CAF2443C4E7081682D /* WidgetViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -515,56 +519,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		5F932BD799BCCCFB7BF7E370237F8BBB /* PBXTargetDependency */ = {
+		504678A8EFF8436B24669BB6CC15995A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = TrustlySDK;
 			target = 77127F2B80807CFC98D2D2E894F9051C /* TrustlySDK */;
-			targetProxy = 8E88BDE303F36F09A2055B861BD1B8E7 /* PBXContainerItemProxy */;
+			targetProxy = 1601B22D308E681D35EE24978F6D0F8D /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		0815BD0B0CADE158E6879600382E3BDC /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9B2E19B944CD9E6BB76FB2C829EAE6A7 /* TrustlySDK.release.xcconfig */;
-			buildSettings = {
-				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = NO;
-				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_PREFIX_HEADER = "Target Support Files/TrustlySDK/TrustlySDK-prefix.pch";
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "Target Support Files/TrustlySDK/TrustlySDK-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/TrustlySDK/TrustlySDK.modulemap";
-				PRODUCT_MODULE_NAME = TrustlySDK;
-				PRODUCT_NAME = TrustlySDK;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_INSTALL_OBJC_HEADER = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		2B9E26EAE2CD392AD762421F663075A1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -631,9 +594,9 @@
 			};
 			name = Debug;
 		};
-		524FD519B7730B8F0BA60C881294608A /* Debug */ = {
+		44A1A382739A9D7680D88996458DAD16 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 21FAA3E7669E55061D067402A7E8B50C /* TrustlySDK.debug.xcconfig */;
+			baseConfigurationReference = DB0126BCBD080EBC363387D66F620939 /* TrustlySDK.debug.xcconfig */;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -773,6 +736,47 @@
 			};
 			name = Debug;
 		};
+		ACB35F89F380EAB70760B2BFBAA16BA2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AA291934F49A73472AE9DD870B7C8F8C /* TrustlySDK.release.xcconfig */;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_PREFIX_HEADER = "Target Support Files/TrustlySDK/TrustlySDK-prefix.pch";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "Target Support Files/TrustlySDK/TrustlySDK-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/TrustlySDK/TrustlySDK.modulemap";
+				PRODUCT_MODULE_NAME = TrustlySDK;
+				PRODUCT_NAME = TrustlySDK;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_INSTALL_OBJC_HEADER = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		F3AA7191626221A0EE9DB1926DE8F446 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BCAFE3A2A24DF1C78F2ED141BEFFC392 /* Pods-ExampleAppUIKit.release.xcconfig */;
@@ -826,11 +830,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		7237AA44895F9C965AEAC0A07BD50754 /* Build configuration list for PBXNativeTarget "TrustlySDK" */ = {
+		A0EF0EC2604E90442E3158A0ED2D6CDF /* Build configuration list for PBXNativeTarget "TrustlySDK" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				524FD519B7730B8F0BA60C881294608A /* Debug */,
-				0815BD0B0CADE158E6879600382E3BDC /* Release */,
+				44A1A382739A9D7680D88996458DAD16 /* Debug */,
+				ACB35F89F380EAB70760B2BFBAA16BA2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ExampleApp/ExampleAppUIKit/Pods/Target Support Files/TrustlySDK/TrustlySDK-Info.plist
+++ b/ExampleApp/ExampleAppUIKit/Pods/Target Support Files/TrustlySDK/TrustlySDK-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>4.2.0</string>
+  <string>4.3.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ ___
 
 | VERSION   | DESCRIPTION   | BRANCH |
 | :-------: | :-----------  | :----------- |
+4.3.0     | Add last used bank. | *main*
 4.2.0     | Add universal link support | *main*
 4.1.0     | Change inAppBrowser integration | *main*
 4.0.0     | Change the SDK design to work with controllers | *main*

--- a/TrustlySDK.podspec
+++ b/TrustlySDK.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
   s.name             = 'TrustlySDK'
 
-  s.version          = '4.2.0'
+  s.version          = '4.3.0'
 
   s.summary          = 'This SDK help the merchants to integrate their solutions with Trustly Widget and LightBox.'
   s.swift_version    = '5.0'

--- a/TrustlySDK/TrustlySDK/Controller/LightBoxViewController.swift
+++ b/TrustlySDK/TrustlySDK/Controller/LightBoxViewController.swift
@@ -183,15 +183,14 @@ extension LightBoxViewController {
     }
     
     private func onReturn(_ returnParameters: [AnyHashable : Any]) -> Void{
+        let establishData = EstablishDataUtils.saveLocalAndRemoveTrustlyContextFrom(establishData: returnParameters)
         
-        if let trustlyContext = returnParameters["trustlyContext"] as? String  {
-            LocalStorage.save(trustlyContext, forKey: Constants.repositoryTrustlyContext)
-        }
-        
-        self.delegate?.onReturn(returnParameters)
+        self.delegate?.onReturn(establishData)
     }
     
     private func onCancel(_ returnParameters: [AnyHashable : Any]) -> Void{
-        self.delegate?.onCancel(returnParameters)
+        let establishData = EstablishDataUtils.saveLocalAndRemoveTrustlyContextFrom(establishData: returnParameters)
+        
+        self.delegate?.onCancel(establishData)
     }
 }

--- a/TrustlySDK/TrustlySDK/Controller/LightBoxViewController.swift
+++ b/TrustlySDK/TrustlySDK/Controller/LightBoxViewController.swift
@@ -183,14 +183,14 @@ extension LightBoxViewController {
     }
     
     private func onReturn(_ returnParameters: [AnyHashable : Any]) -> Void{
-        let establishData = EstablishDataUtils.saveLocalAndRemoveTrustlyContextFrom(establishData: returnParameters)
+        let cleanedReturnParameters = EstablishDataUtils.saveLocalAndRemoveTrustlyContextFrom(establishData: returnParameters)
         
-        self.delegate?.onReturn(establishData)
+        self.delegate?.onReturn(cleanedReturnParameters)
     }
     
     private func onCancel(_ returnParameters: [AnyHashable : Any]) -> Void{
-        let establishData = EstablishDataUtils.saveLocalAndRemoveTrustlyContextFrom(establishData: returnParameters)
+        let cleanedReturnParameters = EstablishDataUtils.saveLocalAndRemoveTrustlyContextFrom(establishData: returnParameters)
         
-        self.delegate?.onCancel(establishData)
+        self.delegate?.onCancel(cleanedReturnParameters)
     }
 }

--- a/TrustlySDK/TrustlySDK/Repository/LocalStorage.swift
+++ b/TrustlySDK/TrustlySDK/Repository/LocalStorage.swift
@@ -15,7 +15,7 @@ final class LocalStorage {
         return userDefaults.string(forKey: key) ?? defaultValue
     }
     
-    static func save(_ value: String, forKey key: String) {
+    static func save(_ value: Any, forKey key: String) {
         userDefaults.set(value,forKey: key)
     }
 }

--- a/TrustlySDK/TrustlySDK/Utils/Constants.swift
+++ b/TrustlySDK/TrustlySDK/Utils/Constants.swift
@@ -47,6 +47,8 @@ struct Constants {
     
     static let baseUrls = ["paywithmybank.com", "trustly.one"]
     
+    static let trustlyContext = "trustlyContext"
+    
     // MARK: OsLog
     static let categoryLogWidgetVC = "widgetViewController"
     static let categoryLogLightboxVC = "lightboxViewController"

--- a/TrustlySDK/TrustlySDK/Utils/Constants.swift
+++ b/TrustlySDK/TrustlySDK/Utils/Constants.swift
@@ -9,7 +9,7 @@ import Foundation
 
 
 struct Constants {
-    static let buildSDK = "4.2.0"
+    static let buildSDK = "4.3.0"
     static let baseDomain = "trustly.one"
     
     static let returnURL = "msg://return"

--- a/TrustlySDK/TrustlySDK/Utils/EstablishDataUtils.swift
+++ b/TrustlySDK/TrustlySDK/Utils/EstablishDataUtils.swift
@@ -202,7 +202,7 @@ struct EstablishDataUtils {
     static func saveLocalAndRemoveTrustlyContextFrom(establishData: [AnyHashable : Any]) -> [AnyHashable : Any] {
         var localEstablishData = establishData
         
-        if let trustlyContext = localEstablishData[Constants.trustlyContext] as? String  {
+        if let trustlyContext = localEstablishData[Constants.trustlyContext] {
             LocalStorage.save(trustlyContext, forKey: Constants.repositoryTrustlyContext)
             localEstablishData.removeValue(forKey: Constants.trustlyContext)
         }

--- a/TrustlySDK/TrustlySDK/Utils/EstablishDataUtils.swift
+++ b/TrustlySDK/TrustlySDK/Utils/EstablishDataUtils.swift
@@ -198,5 +198,16 @@ struct EstablishDataUtils {
         
         return urlScheme.components(separatedBy: ":")[0]
     }
+    
+    static func saveLocalAndRemoveTrustlyContextFrom(establishData: [AnyHashable : Any]) -> [AnyHashable : Any] {
+        var localEstablishData = establishData
+        
+        if let trustlyContext = localEstablishData[Constants.trustlyContext] as? String  {
+            LocalStorage.save(trustlyContext, forKey: Constants.repositoryTrustlyContext)
+            localEstablishData.removeValue(forKey: Constants.trustlyContext)
+        }
+        
+        return localEstablishData
+    }
 
 }

--- a/TrustlySDK/TrustlySDKTests/TrustlySDKControllerTests.swift
+++ b/TrustlySDK/TrustlySDKTests/TrustlySDKControllerTests.swift
@@ -70,6 +70,46 @@ final class TrustlySDKControllerTests: TrustlySDKTestCase {
     }
 
     @MainActor
+    func testLightBoxViewControllerRemovesTrustlyContextFromReturnCallbackParameters() {
+        URLProtocol.registerClass(FailingURLProtocol.self)
+        defer { URLProtocol.unregisterClass(FailingURLProtocol.self) }
+
+        let delegate = TrustlySDKProtocolSpy()
+        let viewController = LightBoxViewController(establishData: makeBaseEstablishData())
+        viewController.delegate = delegate
+
+        viewController.loadViewIfNeeded()
+
+        let webViewManager: WebViewManager? = privateProperty(named: "webViewManager", from: viewController)
+        webViewManager?.returnHandler?(["status": "success", Constants.trustlyContext: "stored-context"])
+
+        XCTAssertEqual(delegate.returnParameters.count, 1)
+        XCTAssertEqual(delegate.returnParameters.first?["status"] as? String, "success")
+        XCTAssertNil(delegate.returnParameters.first?[Constants.trustlyContext])
+        XCTAssertEqual(LocalStorage.getFrom(key: Constants.repositoryTrustlyContext), "stored-context")
+    }
+
+    @MainActor
+    func testLightBoxViewControllerRemovesTrustlyContextFromCancelCallbackParameters() {
+        URLProtocol.registerClass(FailingURLProtocol.self)
+        defer { URLProtocol.unregisterClass(FailingURLProtocol.self) }
+
+        let delegate = TrustlySDKProtocolSpy()
+        let viewController = LightBoxViewController(establishData: makeBaseEstablishData())
+        viewController.delegate = delegate
+
+        viewController.loadViewIfNeeded()
+
+        let webViewManager: WebViewManager? = privateProperty(named: "webViewManager", from: viewController)
+        webViewManager?.cancelHandler?(["reason": "cancelled", Constants.trustlyContext: "stored-context"])
+
+        XCTAssertEqual(delegate.cancelParameters.count, 1)
+        XCTAssertEqual(delegate.cancelParameters.first?["reason"] as? String, "cancelled")
+        XCTAssertNil(delegate.cancelParameters.first?[Constants.trustlyContext])
+        XCTAssertEqual(LocalStorage.getFrom(key: Constants.repositoryTrustlyContext), "stored-context")
+    }
+
+    @MainActor
     func testWidgetViewControllerForwardsBankSelectionToDelegate() {
         let delegate = TrustlySDKProtocolSpy()
         let viewController = WidgetViewController(establishData: makeBaseEstablishData())

--- a/TrustlySDK/TrustlySDKTests/TrustlySDKEstablishAndSettingsTests.swift
+++ b/TrustlySDK/TrustlySDKTests/TrustlySDKEstablishAndSettingsTests.swift
@@ -84,6 +84,26 @@ final class TrustlySDKEstablishAndSettingsTests: TrustlySDKTestCase {
         XCTAssertEqual(prepared["widgetLoaded"] as? String, "true")
     }
 
+    func testSaveLocalAndRemoveTrustlyContextFromStoresAndRemovesTrustlyContext() {
+        let establishData: [AnyHashable: Any] = ["status": "success", Constants.trustlyContext: "stored-context"]
+
+        let filtered = EstablishDataUtils.saveLocalAndRemoveTrustlyContextFrom(establishData: establishData)
+
+        XCTAssertEqual(filtered["status"] as? String, "success")
+        XCTAssertNil(filtered[Constants.trustlyContext])
+        XCTAssertEqual(LocalStorage.getFrom(key: Constants.repositoryTrustlyContext), "stored-context")
+    }
+
+    func testSaveLocalAndRemoveTrustlyContextFromReturnsOriginalWhenNoContextExists() {
+        let establishData: [AnyHashable: Any] = ["status": "success"]
+
+        let filtered = EstablishDataUtils.saveLocalAndRemoveTrustlyContextFrom(establishData: establishData)
+
+        XCTAssertEqual(filtered["status"] as? String, "success")
+        XCTAssertNil(filtered[Constants.trustlyContext])
+        XCTAssertEqual(LocalStorage.getFrom(key: Constants.repositoryTrustlyContext), "")
+    }
+
     func testExtractUrlSchemeReturnsCustomSchemeWithoutSeparator() {
         let establishData: [AnyHashable: Any] = ["metadata.urlScheme": "merchant-app://callback"]
 


### PR DESCRIPTION
### Description

This PR is responsible for remo trustlyContext from the establish.

[DEV-303585](https://trustly.atlassian.net/browse/DEV-303585)
---

### Relevant Commits

- [Remove trustlyContext from establish.](https://github.com/TrustlyInc/trustly-ios/commit/25a2a35e658a0e57c55e0ecc81a2a75e41d265a4)
- [Update SDK version.](https://github.com/TrustlyInc/trustly-ios/commit/bdb2cfd49e4e4ee773d34ce8ab30d2f18aa87313)

---

### Requirements

_(Please check if your pull request fulfills the following requirements)_

- [x] Changes were properly tested (attach evidence if applicable)
- [x] Repository's code-style/linting compliant

---


[DEV-303585]: https://trustly.atlassian.net/browse/DEV-303585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ