### PR TITLE
[DEV-305010] Fixing url encoded for query items

### DIFF
--- a/ExampleApp/ExampleAppUIKit/Podfile.lock
+++ b/ExampleApp/ExampleAppUIKit/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - TrustlySDK (4.3.0)
+  - TrustlySDK (4.3.1)
 
 DEPENDENCIES:
   - TrustlySDK (from `../..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  TrustlySDK: 6b0bfc19c86fdb9e7d94ab7ee05f1add14ea3ecb
+  TrustlySDK: ae6c9315f786d3a5c041ff8cf0f241bb7ef0de9f
 
 PODFILE CHECKSUM: 9b03f9ac6aff4cba6ed3b16b934bd29ebec4ba4e
 

--- a/ExampleApp/ExampleAppUIKit/Pods/Local Podspecs/TrustlySDK.podspec.json
+++ b/ExampleApp/ExampleAppUIKit/Pods/Local Podspecs/TrustlySDK.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "TrustlySDK",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "summary": "This SDK help the merchants to integrate their solutions with Trustly Widget and LightBox.",
   "swift_versions": "5.0",
   "description": "This cocoapods provides the ability to integrate your application with Trustly Widget and LightBox.",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/TrustlyInc/trustly-ios.git",
-    "tag": "4.3.0"
+    "tag": "4.3.1"
   },
   "platforms": {
     "ios": "12.0"

--- a/ExampleApp/ExampleAppUIKit/Pods/Manifest.lock
+++ b/ExampleApp/ExampleAppUIKit/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - TrustlySDK (4.3.0)
+  - TrustlySDK (4.3.1)
 
 DEPENDENCIES:
   - TrustlySDK (from `../..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  TrustlySDK: 6b0bfc19c86fdb9e7d94ab7ee05f1add14ea3ecb
+  TrustlySDK: ae6c9315f786d3a5c041ff8cf0f241bb7ef0de9f
 
 PODFILE CHECKSUM: 9b03f9ac6aff4cba6ed3b16b934bd29ebec4ba4e
 

--- a/ExampleApp/ExampleAppUIKit/Pods/Target Support Files/TrustlySDK/TrustlySDK-Info.plist
+++ b/ExampleApp/ExampleAppUIKit/Pods/Target Support Files/TrustlySDK/TrustlySDK-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>4.3.0</string>
+  <string>4.3.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ ___
 
 | VERSION   | DESCRIPTION   | BRANCH |
 | :-------: | :-----------  | :----------- |
+4.3.1     | Fix encode error. | *main*
 4.3.0     | Add last used bank. | *main*
 4.2.0     | Add universal link support | *main*
 4.1.0     | Change inAppBrowser integration | *main*

--- a/TrustlySDK.podspec
+++ b/TrustlySDK.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
   s.name             = 'TrustlySDK'
 
-  s.version          = '4.3.0'
+  s.version          = '4.3.1'
 
   s.summary          = 'This SDK help the merchants to integrate their solutions with Trustly Widget and LightBox.'
   s.swift_version    = '5.0'

--- a/TrustlySDK/TrustlySDK/Extensions/String+Extension.swift
+++ b/TrustlySDK/TrustlySDK/Extensions/String+Extension.swift
@@ -47,7 +47,7 @@ extension String {
         
         // 2. Strict allowed characters
         var allowed = CharacterSet.alphanumerics
-        allowed.insert(charactersIn: "-_.*")
+        allowed.insert(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~*")
         
         // 3. Percent-encode non-alphanumeric characters
         let encoded = rawString.addingPercentEncoding(withAllowedCharacters: allowed) ?? rawString

--- a/TrustlySDK/TrustlySDK/Extensions/String+Extension.swift
+++ b/TrustlySDK/TrustlySDK/Extensions/String+Extension.swift
@@ -40,4 +40,20 @@ extension String {
             return [:]
         }
     }
+    
+    func urlEncodedForm() -> String {
+        // 1. Remove existing percent-encoding if the string was already encoded
+        let rawString = self.removingPercentEncoding ?? self
+        
+        // 2. Strict allowed characters
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-_.*")
+        
+        // 3. Percent-encode non-alphanumeric characters
+        let encoded = rawString.addingPercentEncoding(withAllowedCharacters: allowed) ?? rawString
+        
+        // 4. Convert spaces to '+'
+        return encoded.replacingOccurrences(of: "%20", with: "+")
+    }
+    
 }

--- a/TrustlySDK/TrustlySDK/Extensions/String+Extension.swift
+++ b/TrustlySDK/TrustlySDK/Extensions/String+Extension.swift
@@ -45,9 +45,8 @@ extension String {
         // 1. Remove existing percent-encoding if the string was already encoded
         let rawString = self.removingPercentEncoding ?? self
         
-        // 2. Strict allowed characters
-        var allowed = CharacterSet.alphanumerics
-        allowed.insert(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~*")
+        // 2. Strict allowed characters (ASCII only for predictable URL encoding)
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~*")
         
         // 3. Percent-encode non-alphanumeric characters
         let encoded = rawString.addingPercentEncoding(withAllowedCharacters: allowed) ?? rawString

--- a/TrustlySDK/TrustlySDK/Helpers/NetworkHelper.swift
+++ b/TrustlySDK/TrustlySDK/Helpers/NetworkHelper.swift
@@ -50,12 +50,14 @@ func buildEnvironment(resourceUrl:ResourceUrls, env: String?, paymentType: Strin
     if let query = query {
         for (key, value) in query {
             if let keyStr = key as? String, let valueStr = value as? String {
-                queryItems.append(URLQueryItem(name: keyStr, value: valueStr))
+                let encodedKey = keyStr.urlEncodedForm()
+                let encodedValue = valueStr.urlEncodedForm()
+                queryItems.append(URLQueryItem(name: encodedKey, value: encodedValue))
             }
         }
     }
     
-    urlComponents.queryItems = queryItems.isEmpty ? nil : queryItems
+    urlComponents.percentEncodedQueryItems = queryItems.isEmpty ? nil : queryItems
     
     // Add fragment (hash)
     if let hash = hash {

--- a/TrustlySDK/TrustlySDK/Utils/Constants.swift
+++ b/TrustlySDK/TrustlySDK/Utils/Constants.swift
@@ -9,7 +9,7 @@ import Foundation
 
 
 struct Constants {
-    static let buildSDK = "4.3.0"
+    static let buildSDK = "4.3.1"
     static let baseDomain = "trustly.one"
     
     static let returnURL = "msg://return"

--- a/TrustlySDK/TrustlySDKTests/TrustlySDKStringExtensionTests.swift
+++ b/TrustlySDK/TrustlySDKTests/TrustlySDKStringExtensionTests.swift
@@ -102,6 +102,12 @@ final class TrustlySDKStringExtensionTests: TrustlySDKTestCase {
         let numericInput = "1175"
         XCTAssertEqual(numericInput.urlEncodedForm(), "1175")
     }
+    
+    /// Test that non-ASCII characters are percent-encoded (UTF-8) to remain safe for use in `percentEncodedQueryItems`
+    func testNonASCIICharactersArePercentEncoded() {
+        let input = "José"
+        XCTAssertEqual(input.urlEncodedForm(), "Jos%C3%A9")
+    }
 
     // MARK: - URLComponents Integration Tests (No Double-Encoding)
 
@@ -118,7 +124,7 @@ final class TrustlySDKStringExtensionTests: TrustlySDKTestCase {
         ]
         
         // CRITICAL: Assigning to percentEncodedQueryItems prevents double-encoding
-        components.percentEncodedQueryItems = queryItems.isEmpty ? nil : queryItems
+        components.percentEncodedQueryItems = queryItems
         
         let urlString = components.url?.absoluteString ?? ""
         
@@ -140,7 +146,7 @@ final class TrustlySDKStringExtensionTests: TrustlySDKTestCase {
         ]
         
         // WRONG: Standard queryItems treats % as a literal character and encodes it to %25
-        components.queryItems = queryItems.isEmpty ? nil : queryItems
+        components.queryItems = queryItems
         
         let urlString = components.url?.absoluteString ?? ""
         

--- a/TrustlySDK/TrustlySDKTests/TrustlySDKStringExtensionTests.swift
+++ b/TrustlySDK/TrustlySDKTests/TrustlySDKStringExtensionTests.swift
@@ -1,0 +1,151 @@
+//
+//  TrustlySDKNetworkHelperTests.swift
+//  TrustlySDK
+//
+//  Created by Andre Guedes on 23/07/26.
+//
+
+import XCTest
+@testable import TrustlySDK
+
+final class TrustlySDKStringExtensionTests: TrustlySDKTestCase {
+    
+    // MARK: - Core Requirement Tests
+        
+    /// Test that email addresses encode @ to %40 and do NOT double-encode (%2540)
+    func testEmailEncoding() {
+        let rawEmail = "user@example.com"
+        XCTAssertEqual(rawEmail.urlEncodedForm(), "user%40example.com")
+    }
+
+    /// Test that pre-encoded emails are handled safely without double-encoding
+    func testPreEncodedEmailHandling() {
+        let preEncodedEmail = "user%40example.com"
+        XCTAssertEqual(preEncodedEmail.urlEncodedForm(), "user%40example.com")
+    }
+
+    /// Test that phone numbers encode + to %2B
+    func testPhoneEncoding() {
+        let rawPhone = "+15551234567"
+        XCTAssertEqual(rawPhone.urlEncodedForm(), "%2B15551234567")
+    }
+
+    /// Test that spaces are converted to '+' (Form URL encoding standard)
+    func testSpacesConvertedToPlus() {
+        let input = "iOS SDK Demo"
+        XCTAssertEqual(input.urlEncodedForm(), "iOS+SDK+Demo")
+    }
+
+    // MARK: - Cryptographic & Special Character Tests
+
+    /// Test Base64 signature encoding (+, /, = symbols)
+    func testSignatureEncoding() {
+        let rawSignature = "aBC123xyz+/KeyHash="
+        let expected = "aBC123xyz%2B%2FKeyHash%3D"
+        XCTAssertEqual(rawSignature.urlEncodedForm(), expected)
+    }
+
+    /// Test device/context strings with colons
+    func testColonEncoding() {
+        let input = "mobile:ios:native"
+        XCTAssertEqual(input.urlEncodedForm(), "mobile%3Aios%3Anative")
+    }
+
+    /// Test custom scheme URLs (slashes and colons)
+    func testCustomSchemeEncoding() {
+        let input = "app://callback"
+        XCTAssertEqual(input.urlEncodedForm(), "app%3A%2F%2Fcallback")
+    }
+
+    // MARK: - Safe Character Preservation Tests
+
+    /// Unreserved characters (- _ . *) should remain unencoded
+    func testUnreservedCharactersArePreserved() {
+        let input = "abc-123_XYZ.test*1"
+        XCTAssertEqual(input.urlEncodedForm(), "abc-123_XYZ.test*1")
+    }
+
+    // MARK: - Dictionary & Query String Integration Test
+
+    /// Test full query string generation from an AnyHashable dictionary
+    func testAnyHashableDictionaryQueryBuilding() {
+        let params: [AnyHashable: AnyHashable] = [
+            "customer.email": "user@example.com",
+            "customer.phone": "+15551234567",
+            "customer.name": "iOS SDK Demo",
+            "version": 2
+        ]
+
+        let queryPairs: [String] = params.compactMap { key, value in
+            let k = "\(key)".urlEncodedForm()
+            let v = "\(value)".urlEncodedForm()
+            return "\(k)=\(v)"
+        }
+
+        // Verify key encoded outputs exist within the query set
+        XCTAssertTrue(queryPairs.contains("customer.email=user%40example.com"))
+        XCTAssertTrue(queryPairs.contains("customer.phone=%2B15551234567"))
+        XCTAssertTrue(queryPairs.contains("customer.name=iOS+SDK+Demo"))
+        XCTAssertTrue(queryPairs.contains("version=2"))
+    }
+    
+    // MARK: - Safe / Plain Text Tests (No Encoding Needed)
+        
+    /// Test that standard alphanumeric strings pass through untouched without any percent-encoding modifications
+    func testAlphanumericStringsRequireNoEncoding() {
+        let plainInput = "Alphanumeric123"
+        XCTAssertEqual(plainInput.urlEncodedForm(), "Alphanumeric123")
+    }
+
+    /// Test that integers converted to string remain completely unmodified
+    func testNumericStringsRequireNoEncoding() {
+        let numericInput = "1175"
+        XCTAssertEqual(numericInput.urlEncodedForm(), "1175")
+    }
+
+    // MARK: - URLComponents Integration Tests (No Double-Encoding)
+
+    /// Verifies that assigning pre-encoded items to `percentEncodedQueryItems`
+    /// DOES NOT perform additional percent-encoding (prevents %2540)
+    func testPercentEncodedQueryItemsDoesNotDoubleEncode() {
+        var components = URLComponents(string: "https://example.com/widget")!
+        
+        // Input is pre-encoded via custom urlEncodedForm()
+        let preEncodedEmail = "user@example.com".urlEncodedForm() // Output: "user%40example.com"
+        
+        let queryItems = [
+            URLQueryItem(name: "customer.email", value: preEncodedEmail)
+        ]
+        
+        // CRITICAL: Assigning to percentEncodedQueryItems prevents double-encoding
+        components.percentEncodedQueryItems = queryItems.isEmpty ? nil : queryItems
+        
+        let urlString = components.url?.absoluteString ?? ""
+        
+        // MUST contain %40 and MUST NOT contain %2540
+        XCTAssertTrue(urlString.contains("customer.email=user%40example.com"))
+        XCTAssertFalse(urlString.contains("customer.email=user%2540example.com"))
+    }
+
+    /// Contrasting test showing how using standard `queryItems` with pre-encoded input
+    /// causes unwanted double-encoding (Failure case verification)
+    func testQueryItemsCausesDoubleEncodingTrap() {
+        var components = URLComponents(string: "https://example.com/widget")!
+        
+        // Input is already encoded
+        let preEncodedEmail = "user%40example.com"
+        
+        let queryItems = [
+            URLQueryItem(name: "customer.email", value: preEncodedEmail)
+        ]
+        
+        // WRONG: Standard queryItems treats % as a literal character and encodes it to %25
+        components.queryItems = queryItems.isEmpty ? nil : queryItems
+        
+        let urlString = components.url?.absoluteString ?? ""
+        
+        // Demonstrates the double-encoding bug
+        XCTAssertTrue(urlString.contains("customer.email=user%2540example.com"))
+    }
+    
+}

--- a/TrustlySDK/TrustlySDKTests/TrustlySDKStringExtensionTests.swift
+++ b/TrustlySDK/TrustlySDKTests/TrustlySDKStringExtensionTests.swift
@@ -1,5 +1,5 @@
 //
-//  TrustlySDKNetworkHelperTests.swift
+//  TrustlySDKStringExtensionTests.swift
 //  TrustlySDK
 //
 //  Created by Andre Guedes on 23/07/26.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -33,7 +33,7 @@ sonar.tests=TrustlySDK/TrustlySDKTests
 # As string expected in destination argument of xcodebuild command
 # Example = sonar.swift.simulator=platform=iOS Simulator,name=iPhone 6,OS=9.2
 # sonar.swift.simulator=platform=iOS Simulator,name=iPhone 7,OS=12.0
-sonar.swift.simulator=platform=iOS Simulator,name=iPhone 16,OS=latest
+sonar.swift.simulator=platform=iOS Simulator,name=iPhone 17 Pro Max,OS=latest
 
 # Xcode project configuration (.xcodeproj)
 # and use the later to specify which project(s) to include in the analysis (comma separated list)


### PR DESCRIPTION
# Pull Request Description

### Description

Fixes query parameter encoding mismatches on iOS when initializing the widget URL. 

Previously, query string building relied on standard `URLComponents.queryItems`, which led to unencoded special characters (e.g., `@` remaining unencoded in emails) or double-encoding bugs (`%2540`) when handling pre-encoded input strings or custom HMAC signatures containing `+`, `/`, and `=`.

This update introduces a custom `urlEncodedForm()` string extension that strictly mimics standard form URL encoding (converting spaces to `+` and encoding reserved characters) and updates URL construction to use `percentEncodedQueryItems` to ensure complete parity across platforms.

---

### Relevant Commits

- **`feat(ios)`**: Add `urlEncodedForm()` extension to handle strict form URL percent-encoding.
- **`fix(ios)`**: Replace `URLComponents.queryItems` with `percentEncodedQueryItems` to prevent double-encoding (`%25`) bugs.
- **`test(ios)`**: Add unit test coverage for `urlEncodedForm()` covering emails, phone numbers, cryptographic signatures, custom schemes, and `percentEncodedQueryItems` assignment.

---

### Requirements

- [x] Changes were properly tested (attach evidence if applicable)
- [x] Repository's code-style/linting compliant

---

### Evidence

All unit test suites (`StringURLEncodedFormTests` and `NoPercentEncodingTests`) passed successfully:

---

### Additional Information

- **Root Cause Analysis:** Standard `URLQueryItem` leaves characters like `@` intact in `CharacterSet.urlQueryAllowed`. Manually percent-encoding values beforehand and passing them to `.queryItems` caused `URLComponents` to escape `%` to `%25`. Switching to `percentEncodedQueryItems` resolves this.